### PR TITLE
fix: improve handling of multiline PR titles and bodies in auto versi…

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -48,8 +48,19 @@ jobs:
           echo "PR Title: $PR_TITLE"
           echo "PR Author: $PR_AUTHOR"
           
-          echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
-          echo "pr_body=$PR_BODY" >> $GITHUB_OUTPUT
+          # Use delimiter to handle multiline content safely
+          {
+            echo "pr_title<<EOF"
+            echo "$PR_TITLE"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+          
+          {
+            echo "pr_body<<EOF"
+            echo "$PR_BODY"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+          
           echo "pr_author=$PR_AUTHOR" >> $GITHUB_OUTPUT
 
       - name: Update pubspec.yaml


### PR DESCRIPTION
…on bump workflow

- Updated the GitHub Actions workflow to safely handle multiline content for PR titles and bodies by using a delimiter.
- This change ensures that multiline text is correctly formatted in the output, enhancing the reliability of the version bump process.