### PR TITLE
fix: restructure CI to work with protected branches

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -12,13 +12,17 @@ permissions:
   pull-requests: write
 
 jobs:
+  # This job acts as the required status check for PRs
   bump-version:
-    if: |
-      (github.event_name == 'push' || (
-        !contains(github.event.pull_request.title, '[skip ci]') &&
-        !contains(github.event.pull_request.title, 'chore: bump version') &&
-        github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-      ))
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Status check passed
+        run: echo "PR status check passed. Version bump will happen after merge."
+
+  # This job runs after a PR is merged to main
+  release:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -28,90 +32,48 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           persist-credentials: true
 
       - name: Check if version bump already done
         id: check_version_bump
         run: |
-          # Fetch main branch to compare commits
-          git fetch origin main --quiet || true
-          
-          HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          
-          echo "Head SHA (PR): $HEAD_SHA"
-          echo "Event type: ${{ github.event.action }}"
-          
-          # Check if the HEAD commit itself is a "chore: bump version" commit
-          # This means the workflow already ran and created the bump commit
-          HEAD_COMMIT_MSG=$(git log -1 --format="%s" "$HEAD_SHA" || echo "")
+          HEAD_COMMIT_MSG=$(git log -1 --format="%s" || echo "")
           echo "HEAD commit message: $HEAD_COMMIT_MSG"
-          
+
           if echo "$HEAD_COMMIT_MSG" | grep -qi "chore: bump version"; then
-            echo "✅ HEAD commit is a version bump commit, skipping..."
+            echo "HEAD commit is a version bump commit, skipping..."
             echo "already_done=true" >> $GITHUB_OUTPUT
           else
-            echo "HEAD commit is not a version bump commit, proceeding with bump"
-            echo "Recent commits:"
-            git log --oneline -5 "$HEAD_SHA"
             echo "already_done=false" >> $GITHUB_OUTPUT
           fi
-          
-          # Always report success to GitHub (so the check passes even if already done)
-          echo "✅ Version bump check completed successfully"
 
-      - name: Get current version (for release)
+      - name: Get current version
         if: steps.check_version_bump.outputs.already_done == 'false'
         id: current_version
         run: |
-          # Fetch main branch to get current version
-          git fetch origin main --quiet || true
-          
-          # Get version from main branch (the version that will be released)
-          # First try from main branch, fallback to current branch
-          CURRENT_VERSION=$(git show origin/main:pubspec.yaml 2>/dev/null | grep "^version:" | head -1 | sed 's/version:[[:space:]]*//' | tr -d '\r' || echo "")
-          
-          # If we couldn't get it from main, try current branch
-          if [ -z "$CURRENT_VERSION" ] || [ "$CURRENT_VERSION" = "" ]; then
-            CURRENT_VERSION=$(grep "^version:" pubspec.yaml | head -1 | sed 's/version:[[:space:]]*//' | tr -d '\r' || echo "")
-          fi
-          
-          # Validate version format (should be X.Y.Z)
+          CURRENT_VERSION=$(grep "^version:" pubspec.yaml | head -1 | sed 's/version:[[:space:]]*//' | tr -d '\r')
+
           if ! echo "$CURRENT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
-            echo "❌ Error: Could not extract valid version. Got: '$CURRENT_VERSION'"
-            echo "📋 pubspec.yaml content:"
-            cat pubspec.yaml | grep -A 5 "version:"
+            echo "Error: Could not extract valid version. Got: '$CURRENT_VERSION'"
             exit 1
           fi
-          
-          echo "Current version (for release): $CURRENT_VERSION"
+
+          echo "Current version: $CURRENT_VERSION"
           echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Get PR information
+      - name: Get merge commit information
+        if: steps.check_version_bump.outputs.already_done == 'false'
         id: pr_info
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            let title = '';
-            let body = '';
-
-            if (context.eventName === 'pull_request') {
-              title = context.payload.pull_request?.title || '';
-              body = context.payload.pull_request?.body || '';
-            } else {
-              // For push events, use commit message
-              const commit = context.payload.head_commit;
-              title = commit?.message?.split('\n')[0] || '';
-              body = commit?.message?.split('\n').slice(1).join('\n').trim() || '';
-            }
-
-            // Write to temp files to avoid shell interpretation of special characters
+            const commit = context.payload.head_commit;
+            const title = commit?.message?.split('\n')[0] || '';
+            const body = commit?.message?.split('\n').slice(1).join('\n').trim() || '';
             fs.writeFileSync('/tmp/pr_title.txt', title);
             fs.writeFileSync('/tmp/pr_body.txt', body);
-
-            // Also set outputs for steps that need them
             core.setOutput('pr_title', title);
 
       - name: Configure Git
@@ -119,63 +81,55 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git config --local pull.rebase false
-          git config --local pull.ff only
 
-      - name: Extract release notes from CHANGELOG (current version)
+      - name: Extract release notes from CHANGELOG
         if: steps.check_version_bump.outputs.already_done == 'false'
         id: release_notes
         run: |
           VERSION="${{ steps.current_version.outputs.version }}"
-          # Extract the changelog entry for current version
           RELEASE_NOTES=$(awk "/^## \[$VERSION\]/,/^## \[/" CHANGELOG.md | sed '/^## \[/d' | sed '/^$/d' | head -n 20)
           echo "notes<<EOF" >> $GITHUB_OUTPUT
           echo "$RELEASE_NOTES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Create Git tag (current version)
+      - name: Create Git tag
         if: steps.check_version_bump.outputs.already_done == 'false'
         run: |
           VERSION="${{ steps.current_version.outputs.version }}"
           TAG_NAME="v$VERSION"
-          
-          # Check if tag already exists
+
           if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-            echo "⚠️ Tag $TAG_NAME already exists, skipping tag creation"
+            echo "Tag $TAG_NAME already exists, skipping"
           else
             git tag -a "$TAG_NAME" -m "Release v$VERSION"
             git push origin "$TAG_NAME"
-            echo "✅ Created and pushed tag $TAG_NAME"
+            echo "Created and pushed tag $TAG_NAME"
           fi
 
-      - name: Create GitHub Release (current version)
+      - name: Create GitHub Release
         if: steps.check_version_bump.outputs.already_done == 'false'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ steps.current_version.outputs.version }}
-          name: FlutterForge CLI v${{ steps.current_version.outputs.version }}
+          name: VGV CLI v${{ steps.current_version.outputs.version }}
           body: |
-            ## 🚀 What's New in v${{ steps.current_version.outputs.version }}
-            
+            ## What's New in v${{ steps.current_version.outputs.version }}
+
             ${{ steps.release_notes.outputs.notes }}
-            
+
             ---
-            
-            ### 📦 Installation
-            
+
+            ### Installation
+
             ```bash
-            dart pub global activate --source git https://github.com/victorsdd01/flutter_forge.git
+            dart pub global activate --source git https://github.com/victorsdd01/vgv_cli.git
             ```
-            
-            ### 🔄 Update
-            
+
+            ### Update
+
             ```bash
-            flutterforge --update
+            vgv --update
             ```
-            
-            ### 📚 Full Changelog
-            
-            See [CHANGELOG.md](https://github.com/victorsdd01/flutter_forge/blob/main/CHANGELOG.md) for the complete list of changes.
           draft: false
           prerelease: false
         env:
@@ -186,28 +140,12 @@ jobs:
         id: new_version
         run: |
           CURRENT_VERSION="${{ steps.current_version.outputs.version }}"
-          
-          # Validate current version format
-          if ! echo "$CURRENT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
-            echo "❌ Error: Invalid version format: $CURRENT_VERSION"
-            exit 1
-          fi
-          
-          # Parse version parts (ej: "1.10.0" -> "1", "10", "0")
           MAJOR=$(echo "$CURRENT_VERSION" | cut -d '.' -f 1)
           MINOR=$(echo "$CURRENT_VERSION" | cut -d '.' -f 2)
           PATCH=$(echo "$CURRENT_VERSION" | cut -d '.' -f 3)
-          
-          # Validate parsed parts are numbers
-          if ! [[ "$MAJOR" =~ ^[0-9]+$ ]] || ! [[ "$MINOR" =~ ^[0-9]+$ ]] || ! [[ "$PATCH" =~ ^[0-9]+$ ]]; then
-            echo "❌ Error: Could not parse version parts. Major: $MAJOR, Minor: $MINOR, Patch: $PATCH"
-            exit 1
-          fi
-          
-          # Increment patch version (1.10.0 -> 1.10.1)
           NEW_PATCH=$((PATCH + 1))
           NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
-          
+
           echo "Current version: $CURRENT_VERSION"
           echo "New version: $NEW_VERSION"
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
@@ -216,33 +154,14 @@ jobs:
         if: steps.check_version_bump.outputs.already_done == 'false'
         run: |
           NEW_VERSION="${{ steps.new_version.outputs.version }}"
-          
-          # Validate new version format
-          if ! echo "$NEW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
-            echo "❌ Error: Invalid new version format: $NEW_VERSION"
-            exit 1
-          fi
-          
-          # Update version in pubspec.yaml (handle both "version: X.Y.Z" and "version: X.Y.Z+1" formats)
-          if grep -q "^version:" pubspec.yaml; then
-            # Replace the version line, preserving any build number if present
-            sed -i "s/^version:[[:space:]]*[0-9]\+\.[0-9]\+\.[0-9]\+.*/version: $NEW_VERSION/" pubspec.yaml
-          else
-            echo "❌ Error: Could not find version line in pubspec.yaml"
-            exit 1
-          fi
-          
-          # Verify the update
+          sed -i "s/^version:[[:space:]]*[0-9]\+\.[0-9]\+\.[0-9]\+.*/version: $NEW_VERSION/" pubspec.yaml
+
           UPDATED_VERSION=$(grep "^version:" pubspec.yaml | head -1 | sed 's/version:[[:space:]]*//' | tr -d '\r')
           if [ "$UPDATED_VERSION" != "$NEW_VERSION" ]; then
-            echo "❌ Error: Version update failed. Expected: $NEW_VERSION, Got: $UPDATED_VERSION"
-            echo "📋 pubspec.yaml content:"
-            cat pubspec.yaml | grep -A 5 "version:"
+            echo "Error: Version update failed. Expected: $NEW_VERSION, Got: $UPDATED_VERSION"
             exit 1
           fi
-          
-          echo "✅ Updated pubspec.yaml:"
-          grep "version:" pubspec.yaml
+          echo "Updated pubspec.yaml to $NEW_VERSION"
 
       - name: Update CHANGELOG.md
         if: steps.check_version_bump.outputs.already_done == 'false'
@@ -251,27 +170,10 @@ jobs:
         run: |
           DATE=$(date +%Y-%m-%d)
 
-          # Read PR title and body safely from files (avoids shell interpretation of backticks)
           PR_TITLE=$(cat /tmp/pr_title.txt 2>/dev/null || echo "")
-          PR_BODY=$(cat /tmp/pr_body.txt 2>/dev/null || echo "")
-
-          # Clean PR title (remove version tags like [MINOR], [MAJOR], etc.)
           CLEAN_TITLE=$(printf '%s' "$PR_TITLE" | sed 's/\[MINOR\]//g' | sed 's/\[MAJOR\]//g' | sed 's/\[PATCH\]//g' | sed 's/\[SKIP\]//g' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
+          CHANGELOG_CONTENT="- $CLEAN_TITLE"
 
-          # Extract changelog content from PR body if it exists
-          CHANGELOG_CONTENT=""
-          if printf '%s' "$PR_BODY" | grep -qiE "## (Changelog|What's New|Changes)"; then
-            CHANGELOG_CONTENT=$(printf '%s' "$PR_BODY" | sed -n '/## [Cc]hangelog\|## [Ww]hat'\''s [Nn]ew\|## [Cc]hanges/I,/^##/p' | sed '/^##/d' | sed '/^$/d' | head -n 10)
-          fi
-
-          # If no changelog content found, use PR title
-          if [ -z "$CHANGELOG_CONTENT" ] || [ "$CHANGELOG_CONTENT" = "" ]; then
-            CHANGELOG_CONTENT="- $CLEAN_TITLE"
-          else
-            CHANGELOG_CONTENT=$(printf '%s' "$CHANGELOG_CONTENT" | sed 's/^/- /' | sed 's/^- -/-/')
-          fi
-
-          # Create Python script file
           cat > /tmp/update_changelog.py << 'PYEOF'
           import re
           import os
@@ -280,7 +182,6 @@ jobs:
           date = os.environ.get('DATE', '')
           changelog_content = os.environ.get('CHANGELOG_CONTENT', '')
 
-          # Create new changelog entry
           new_entry = f"""## [{version}] - {date}
 
           ### Changes
@@ -288,83 +189,50 @@ jobs:
 
           """
 
-          # Read current CHANGELOG
           with open('CHANGELOG.md', 'r', encoding='utf-8') as f:
               content = f.read()
 
-          # Find [Unreleased] section and insert after it
           if '## [Unreleased]' in content:
-              # Find the end of [Unreleased] section (after the last item before next ##)
               pattern = r'(## \[Unreleased\].*?\n\n)'
               match = re.search(pattern, content, re.DOTALL)
               if match:
-                  # Insert new version after [Unreleased] section
                   insert_pos = match.end()
                   content = content[:insert_pos] + new_entry + content[insert_pos:]
               else:
-                  # Fallback: insert after [Unreleased] line
                   content = content.replace('## [Unreleased]', f'## [Unreleased]\n\n{new_entry}', 1)
           else:
-              # Insert after header (after line 7)
               lines = content.split('\n')
               lines.insert(8, new_entry.strip())
               content = '\n'.join(lines)
 
-          # Write updated content
           with open('CHANGELOG.md', 'w', encoding='utf-8') as f:
               f.write(content)
 
-          print(f"✅ Updated CHANGELOG.md with version {version}")
+          print(f"Updated CHANGELOG.md with version {version}")
           PYEOF
 
-          # Execute Python script with environment variables
           export VERSION="$VERSION"
           export DATE="$DATE"
           export CHANGELOG_CONTENT="$CHANGELOG_CONTENT"
           python3 /tmp/update_changelog.py
 
-          echo ""
-          echo "📋 New changelog entry preview:"
-          head -n 25 CHANGELOG.md
-
-      - name: Commit and push version bump to PR branch
+      - name: Create version bump PR
         if: steps.check_version_bump.outputs.already_done == 'false'
-        run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
-          
-          # Check if version files have changed
-          if git diff --quiet pubspec.yaml CHANGELOG.md; then
-            echo "⚠️ No changes to version files, skipping commit"
-            exit 0
-          fi
-          
-          # Save the modified files to temporary location
-          cp pubspec.yaml /tmp/pubspec.yaml.bak
-          cp CHANGELOG.md /tmp/CHANGELOG.md.bak
-          
-          # Fetch and checkout the branch (this will discard our changes, but we saved them)
-          git fetch origin "$BRANCH_NAME" --quiet || true
-          git checkout -f "$BRANCH_NAME" || git checkout -b "$BRANCH_NAME" "origin/$BRANCH_NAME"
-          
-          # Restore our modified files
-          cp /tmp/pubspec.yaml.bak pubspec.yaml
-          cp /tmp/CHANGELOG.md.bak CHANGELOG.md
-          
-          # Pull latest changes if any
-          git pull origin "$BRANCH_NAME" --no-rebase --no-edit || true
-          
-          # Stage only the version files
-          git add pubspec.yaml CHANGELOG.md
-          
-          # Commit the version bump
-          git commit -m "chore: bump version to ${{ steps.new_version.outputs.version }}"
-          
-          # Push to PR branch
-          git push origin "$BRANCH_NAME" --force-with-lease || {
-            echo "⚠️ Force-with-lease failed, trying regular push..."
-            git push origin "$BRANCH_NAME"
-          }
-          
-          echo "✅ Version bumped to ${{ steps.new_version.outputs.version }} and pushed to PR branch"
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_VERSION="${{ steps.new_version.outputs.version }}"
+          BUMP_BRANCH="chore/bump-version-$NEW_VERSION"
+
+          # Create a new branch for the version bump
+          git checkout -b "$BUMP_BRANCH"
+          git add pubspec.yaml CHANGELOG.md
+          git commit -m "chore: bump version to $NEW_VERSION"
+          git push origin "$BUMP_BRANCH"
+
+          # Create a PR targeting main
+          gh pr create \
+            --base main \
+            --head "$BUMP_BRANCH" \
+            --title "chore: bump version to $NEW_VERSION" \
+            --body "Automated version bump to $NEW_VERSION after release."


### PR DESCRIPTION
## Summary
- Split workflow into two jobs to work with branch protection rules
- **bump-version** job: runs on PRs targeting main, acts as required status check (pass-through)
- **release** job: runs on push to main (after merge), creates tag + GitHub release, then opens a separate PR for the version bump instead of pushing directly to protected branches
- Also cleaned up old FlutterForge references in the release template

## Test plan
- [ ] Verify bump-version status check passes on PRs
- [ ] Verify release job creates tag, release, and version bump PR after merge to main