### PR TITLE
fix: use PAT_TOKEN for PR creation in CI

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Create version bump PR
         if: steps.check_version_bump.outputs.already_done == 'false'
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           NEW_VERSION="${{ steps.new_version.outputs.version }}"
           BUMP_BRANCH="chore/bump-version-$NEW_VERSION"


### PR DESCRIPTION
## Summary
- Use GH_TOKEN with PAT_TOKEN instead of GITHUB_TOKEN for gh CLI
- Fixes: GitHub Actions is not permitted to create or approve pull requests

## Test plan
- [ ] Verify release job can create version bump PR after merge to main