### PR TITLE
fix: handle existing bump branch in CI

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -224,15 +224,23 @@ jobs:
           NEW_VERSION="${{ steps.new_version.outputs.version }}"
           BUMP_BRANCH="chore/bump-version-$NEW_VERSION"
 
+          # Delete remote branch if it already exists (from a previous failed run)
+          git push origin --delete "$BUMP_BRANCH" 2>/dev/null || true
+
           # Create a new branch for the version bump
           git checkout -b "$BUMP_BRANCH"
           git add pubspec.yaml CHANGELOG.md
           git commit -m "chore: bump version to $NEW_VERSION"
           git push origin "$BUMP_BRANCH"
 
-          # Create a PR targeting main
-          gh pr create \
-            --base main \
-            --head "$BUMP_BRANCH" \
-            --title "chore: bump version to $NEW_VERSION" \
-            --body "Automated version bump to $NEW_VERSION after release."
+          # Create a PR targeting main (skip if one already exists)
+          EXISTING_PR=$(gh pr list --head "$BUMP_BRANCH" --json number -q '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists for $BUMP_BRANCH, skipping creation"
+          else
+            gh pr create \
+              --base main \
+              --head "$BUMP_BRANCH" \
+              --title "chore: bump version to $NEW_VERSION" \
+              --body "Automated version bump to $NEW_VERSION after release."
+          fi


### PR DESCRIPTION
## Summary
- Delete existing remote bump branch before pushing (handles retries from failed runs)
- Skip PR creation if one already exists for the bump branch