### PR TITLE
fix: resolve garbled spinner output and CI infinite version bump loop

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -41,8 +41,12 @@ jobs:
           HEAD_COMMIT_MSG=$(git log -1 --format="%s" || echo "")
           echo "HEAD commit message: $HEAD_COMMIT_MSG"
 
+          # Check if HEAD commit is a version bump commit OR a merge of a bump branch
           if echo "$HEAD_COMMIT_MSG" | grep -qi "chore: bump version"; then
             echo "HEAD commit is a version bump commit, skipping..."
+            echo "already_done=true" >> $GITHUB_OUTPUT
+          elif echo "$HEAD_COMMIT_MSG" | grep -qi "chore/bump-version"; then
+            echo "HEAD commit is a merge of a version bump branch, skipping..."
             echo "already_done=true" >> $GITHUB_OUTPUT
           else
             echo "already_done=false" >> $GITHUB_OUTPUT

--- a/lib/data/datasources/flutter_command_datasource.dart
+++ b/lib/data/datasources/flutter_command_datasource.dart
@@ -131,12 +131,12 @@ class FlutterCommandDataSourceImpl implements FlutterCommandDataSource {
       );
 
       if (result.exitCode != 0) {
-        stderr.writeln('Warning: Failed to generate localization files. You may need to run "dart run intl_utils:generate" manually.');
+        // Silent: runs during spinner animation
       }
 
       await _fixAppLocalizationsImport(projectName);
-    } catch (e) {
-      stderr.writeln('Warning: Failed to generate localization files: $e');
+    } catch (_) {
+      // Silent: runs during spinner animation
     }
   }
 
@@ -153,8 +153,8 @@ class FlutterCommandDataSourceImpl implements FlutterCommandDataSource {
 
         appLocalizationsFile.writeAsStringSync(content);
       }
-    } catch (e) {
-      stderr.writeln('Warning: Could not fix app_localizations import: $e');
+    } catch (_) {
+      // Silent: runs during spinner animation
     }
   }
 
@@ -176,8 +176,8 @@ class FlutterCommandDataSourceImpl implements FlutterCommandDataSource {
           runInShell: true,
         );
       }
-    } catch (e) {
-      stderr.writeln('Warning: Failed to clean build cache: $e');
+    } catch (_) {
+      // Silent: runs during spinner animation
     }
   }
 
@@ -192,10 +192,10 @@ class FlutterCommandDataSourceImpl implements FlutterCommandDataSource {
       );
 
       if (result.exitCode != 0) {
-        stderr.writeln('Warning: build_runner failed. You may need to run "dart run build_runner build -d" manually.');
+        // Silent: runs during spinner animation
       }
-    } catch (e) {
-      stderr.writeln('Warning: Failed to run build_runner: $e');
+    } catch (_) {
+      // Silent: runs during spinner animation
     }
   }
 
@@ -258,8 +258,8 @@ class FlutterCommandDataSourceImpl implements FlutterCommandDataSource {
           await Process.run('pod', ['install', '--repo-update'], workingDirectory: macosPath, runInShell: true);
         }
       }
-    } catch (e) {
-      stderr.writeln('Warning: CocoaPods setup failed: $e. You can run "pod install" manually.');
+    } catch (_) {
+      // Silent: runs during spinner animation
     }
   }
 }


### PR DESCRIPTION
## Summary
- Revert `stderr.writeln` to silent catches in datasource methods that run during spinner animation (fixes garbled terminal output)
- Add branch name check (`chore/bump-version`) in CI workflow to detect merge commits from version bump PRs (fixes infinite loop)

## Test plan
- [ ] Create a new project and verify no garbled text appears during spinner
- [ ] Merge to main and verify only one version bump PR is created