### PR TITLE
fix: update form_builder_validators for intl compatibility

### DIFF
--- a/lib/data/datasources/file_system_datasource.dart
+++ b/lib/data/datasources/file_system_datasource.dart
@@ -59,8 +59,8 @@ class FileSystemDataSourceImpl implements FileSystemDataSource {
           'pretty_dio_logger: ^1.4.0',
           'talker_dio_logger: ^4.4.1',
           'talker_flutter: ^4.4.1',
-          'flutter_form_builder: ^9.4.1',
-          'form_builder_validators: ^10.0.1',
+          'flutter_form_builder: ^9.5.0',
+          'form_builder_validators: ^11.2.0',
           'drift: ^2.18.0',
           'sqlite3_flutter_libs: ^0.5.0',
         ]);


### PR DESCRIPTION
## Summary
- Update `form_builder_validators` from `^10.0.1` to `^11.2.0`
- Update `flutter_form_builder` from `^9.4.1` to `^9.5.0`
- Fixes version solving failure: `form_builder_validators ^10.x` requires `intl ^0.19.0` which conflicts with Flutter SDK's pinned `intl 0.20.2`

## Test plan
- [ ] Generate a project with the CLI and verify `dart run build_runner build -d` succeeds