### PR TITLE
fix: prevent infinite CI version bump loop

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -234,7 +234,7 @@ jobs:
           # Create a new branch for the version bump
           git checkout -b "$BUMP_BRANCH"
           git add pubspec.yaml CHANGELOG.md
-          git commit -m "chore: bump version to $NEW_VERSION"
+          git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
           git push origin "$BUMP_BRANCH"
 
           # Create a PR targeting main (skip if one already exists)


### PR DESCRIPTION
## Summary
- Add `[skip ci]` to version bump commit messages
- The bump branch is pushed with `PAT_TOKEN` which triggers workflows (unlike `GITHUB_TOKEN`). When the bump PR is merged, the push event re-triggers the workflow, creating another bump — infinite loop.
- `[skip ci]` in the commit message prevents GitHub Actions from running on that push event.

## Root cause
PRs #46-#52 show the loop: each merge of a bump PR triggered another version bump.

## Test plan
- [ ] Merge a PR to main and verify only one bump PR is created
- [ ] Merge the bump PR and verify no new bump PR appears