### PR TITLE
fix: prevent infinite CI version bump loop

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -234,7 +234,7 @@ jobs:
           # Create a new branch for the version bump
           git checkout -b "$BUMP_BRANCH"
           git add pubspec.yaml CHANGELOG.md
-          git commit -m "chore: bump version to $NEW_VERSION"
+          git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
           git push origin "$BUMP_BRANCH"
 
           # Create a PR targeting main (skip if one already exists)


### PR DESCRIPTION
## Summary
- Add `[skip ci]` to version bump commit messages to prevent infinite workflow loop
- PAT_TOKEN pushes trigger workflows unlike GITHUB_TOKEN, causing each bump merge to create another bump

## Test plan
- [ ] After merge, verify only one bump PR is created
- [ ] Merge the bump PR and confirm no new bump PR appears