### PR TITLE
release: flavors nativos + UI mason_logger + fix update/version + bug fixes (v1.10.50)

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -167,6 +167,16 @@ jobs:
           fi
           echo "Updated pubspec.yaml to $NEW_VERSION"
 
+      - name: Sync baked version constant
+        if: steps.check_version_bump.outputs.already_done == 'false'
+        run: |
+          NEW_VERSION="${{ steps.new_version.outputs.version }}"
+          # Keep lib/src/version.dart (the runtime source of truth) in sync
+          # with pubspec.yaml. No Dart toolchain needed in CI — just sed.
+          sed -i "s/const String packageVersion = '.*';/const String packageVersion = '$NEW_VERSION';/" lib/src/version.dart
+          echo "Synced lib/src/version.dart to $NEW_VERSION"
+          grep "packageVersion" lib/src/version.dart
+
       - name: Update CHANGELOG.md
         if: steps.check_version_bump.outputs.already_done == 'false'
         env:
@@ -233,7 +243,7 @@ jobs:
 
           # Create a new branch for the version bump
           git checkout -b "$BUMP_BRANCH"
-          git add pubspec.yaml CHANGELOG.md
+          git add pubspec.yaml CHANGELOG.md lib/src/version.dart
           git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
           git push origin "$BUMP_BRANCH"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,15 @@ Configurar **flavors nativos reales** (Android `productFlavors` en `build.gradle
 ### 2. Bugs al actualizar
 Al hacer `vgv -u` había bugs. Revisar el flujo de update en `lib/vgv_cli.dart` (`_updateCLI`, `_checkForUpdates`, `_showUpdateProgress`) y `version_checker.dart`.
 
+**Causa raíz (con evidencia, 2026-08-07):** no hay una fuente única de verdad de versión y discrepan entre sí:
+- `main` pubspec → **1.10.49** (bump `d8dfebb`, 2026-03-08, **sin tag ni release**)
+- último git tag / GitHub Release → **v1.10.48** (2026-03-07)
+- pub.dev → **1.10.41** (muy atrasado)
+
+El `[skip ci]` del fix `977bd56` (para cortar el loop infinito del bump) también evitó que se tagueara/publicara el bump final → por eso 1.10.49 quedó sin tag/release. `getLatestCLIVersion()` lee releases (1.10.48) y `getLatestCLIVersionFromGit()` lee main pubspec (1.10.49) → inconsistencia. Además `getCurrentVersion()` lee primero `~/.vgv_version` (caché que queda viejo y tapa la versión real) y su fallback "dev mode" lee el pubspec del **CWD** (no el del CLI). Al actualizar, guarda la versión *esperada del remoto*, no la *realmente instalada*.
+
+**Fix pendiente (2 frentes):** (a) código — elegir canal canónico único + versión horneada (constante Dart generada, estilo Mason) y eliminar el `~/.vgv_version` frágil; (b) CI — que el bump final sí genere su tag/release sin reactivar el loop.
+
 ### Ideas / features futuras
 - Preguntar en interactivo por state management / arquitectura (ya soportado en enums).
 - Limpiar artefactos de build versionados en `templates/blocs/build/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,21 @@ Configurar **flavors nativos reales** (Android `productFlavors` en `build.gradle
 - Implementado: entidad `Flavor` (`project_config.dart`), prompt (`cli_controller.dart`), preview de bundle IDs en el resumen, inyección Android + **iOS** (`configureFlavors` en `file_system_datasource.dart`, llamado desde `project_repository_impl.dart` tras `flutter create`).
   - iOS: genera xcconfig `<BuildType>-<flavor>.xcconfig` (con `FLUTTER_TARGET`, `PRODUCT_BUNDLE_IDENTIFIER`, `BUNDLE_DISPLAY_NAME`), duplica las build configs Debug/Release/Profile → `-<flavor>` en las 3 config lists del `pbxproj` (bundle id por flavor solo en el target Runner), y crea schemes `<flavor>.xcscheme`. Ids de pbxproj generados con prefijo `FF` (sin colisión con flutter). **Validado con `xcodebuild -list`** (reconoce configs y schemes).
   - Parte 4 (✅): `launch.json` flavor-aware (una config por flavor×modo con `"args":["--flavor",...]`), poda de entry points `main_<f>.dart` no seleccionados, y "Next steps" del CLI con `flutter run --flavor`.
-  - **Pendiente: verificación build real (Parte 5).**
+  - Parte 5 (✅) **verificación end-to-end con builds reales**: se generó `flavor_test` con el CLI (147s) y se compilaron ambas plataformas:
+    - Android: `✓ app-dev-debug.apk` (flavor dev). **Requirió fix**: AGP 8+ necesita `buildFeatures { resValues = true }` para `resValue app_name` (sin eso el build falla). Ya inyectado.
+    - iOS: `✓ Runner.app`, bundle `com.flavortest.flavorTest.dev` (flavor dev aplicado).
+    - Chequeos confirmados en el proyecto generado: auth state con **freezed** (igual que JornaDay), build_runner generó `*.freezed.dart`/`*.g.dart`, capas de datos completas (data/domain/presentation en auth+home), states custom `core/states/tstateless.dart` + `tstatefull.dart`.
+
+### 1.c Bug hunt del CLI (feature #9) — hallazgos y estado
+Análisis exhaustivo del CLI (2026-08-07). Arreglados:
+- **P1** `-o/--output` se ignoraba (proyecto siempre en CWD) → `createProject` ahora hace `Directory.current = outputDir`.
+- **P1** `--no-git` no hacía nada y además `flutter create` no inicializa git → nuevo `initializeGit` (git init + add) que corre salvo `--no-git`.
+- **P2** flavors en proyectos web/desktop-only rompían (`--flavor` no soportado) → `launch.json` y hints omiten `--flavor` si no hay mobile (`ProjectConfig.usesNativeFlavors`).
+- **P2** `addDependencies` corrompía el pubspec (metía el SDK de flutter y `cupertino_icons` bajo `dev_dependencies`) → reescrito para insertar tras cada header de sección preservando lo existente.
+- **P2** Android `resValues` (ver Parte 5).
+- **P3** regex de org aceptaba puntos consecutivos (`com..x`) → corregida; `compareVersions` podía lanzar `FormatException` → parseo defensivo; `getLatestCLIVersion` sin timeout → timeout 10s.
+
+Pendientes (menor prioridad, ver #9): reporte de éxito engañoso cuando build_runner/l10n/pods fallan en silencio (P2); use cases de dominio (`CreateProjectUseCase`/`ValidateProjectConfigUseCase`) nunca se invocan → sin pre-check limpio de "flutter no instalado" (P2); barra de progreso de update falsa (cosmético); exit code 0 en fallos de validación; flags ignoradas fuera de flag-mode.
 
 ### 2. Bugs al actualizar
 Al hacer `vgv -u` había bugs. Revisar el flujo de update en `lib/vgv_cli.dart` (`_updateCLI`, `_checkForUpdates`, `_showUpdateProgress`) y `version_checker.dart`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,13 +79,16 @@ vgv -q -n my_app            # quick mode con defaults
 vgv -n my_app --org com.x   # con organización
 vgv -n my_app -o ~/proj     # directorio de salida
 vgv -n my_app --no-git      # sin git init
+vgv -q -n my_app --flavors dev,prod   # elegir flavors sin interactivo
 vgv --dry-run -n my_app     # preview sin crear archivos
 vgv -h                      # help
 vgv -v                      # versión + check de updates
 vgv -u                      # auto-update (reinstala desde git)
 ```
 
-Flags: `--help/-h`, `--version/-v`, `--update/-u`, `--quick/-q`, `--name/-n`, `--org`, `--output/-o`, `--no-git`, `--dry-run`.
+Flags: `--help/-h`, `--version/-v`, `--update/-u`, `--quick/-q`, `--name/-n`, `--org`, `--output/-o`, `--flavors`, `--no-git`, `--dry-run`.
+
+`--flavors <lista>` (ej. `dev,staging,prod`) permite elegir flavors **sin** modo interactivo (por defecto los 3); tokens tolerantes (`dev/development`, `stg/stage/staging`, `prod/production`); token inválido → error + `exit(1)`. También sirve como pre-selección en modo interactivo (salta el prompt de flavors). Además `--org/-o/--no-git` ahora se honran aunque caigas a interactivo (antes se ignoraban).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,22 @@ Flags: `--help/-h`, `--version/-v`, `--update/-u`, `--quick/-q`, `--name/-n`, `-
 Migrado de `interact` a **`mason_logger`** (el logger de Mason CLI, hecho por Very Good Ventures — mismo ecosistema que VGV). `cli_controller.dart` ahora usa `chooseOne`/`chooseAny` (multi-select estilo inquirer), `prompt`, `confirm` y `progress`. `interact` removido.
 
 ### 1.b Flavors nativos + entry points (EN CURSO — feature grande)
-Configurar **flavors nativos reales** (Android `productFlavors` en `build.gradle.kts` + iOS build configs/schemes en `pbxproj`) con **bundleID distinto por entorno** (dev/staging/production), app name por flavor, y entry points cableados con `--flavor`. **Preguntar en la creación qué flavors quiere** (los 3 o un subconjunto). Hoy solo hay "entornos por código" (entry points main_dev/staging/production + `AppEnvironment`), NO flavors nativos. Flutter local: 3.44.8, Android usa Kotlin DSL (`build.gradle.kts`).
+Configurar **flavors nativos reales** (Android `productFlavors` en `build.gradle.kts` + iOS build configs/schemes en `pbxproj`) con **bundleID distinto por flavor**, app name por flavor, y entry points cableados con `--flavor`. El prompt (`chooseAny`) permite elegir 3, 2 o 1 flavor. Referencia de la convención: **el proyecto JornaDay** (`/Users/victorsdd/Desktop/JornaDay`), creado con la versión buena del CLI que se perdió.
+
+**Convención de flavors confirmada** (el bundleID que escribe el usuario ES production/base; los demás derivan sufijo). Base `com.test.app`:
+
+| Flavor | flavorName (`--flavor`, gradle, iOS scheme) | entry point | bundleId | app name |
+|--------|------|------|------|------|
+| production | `prod` | `main_production.dart` | `com.test.app` (limpio) | Test App |
+| dev | `dev` | `main_dev.dart` | `com.test.app.dev` | Test App Dev |
+| staging | `staging` | `main_staging.dart` | `com.test.app.stage` | Test App Stage |
+
+- Base id real = `${organizationName}.${projectName}` (así lo arma `flutter create --org`).
+- Android: `flavorDimensions += "environment"`, `applicationIdSuffix` por flavor (prod sin sufijo), `resValue("string","app_name",...)`, y `AndroidManifest` con `android:label="@string/app_name"`.
+- iOS: xcconfig `Debug/Release/Profile-<flavorName>.xcconfig` con `FLUTTER_TARGET`, `PRODUCT_BUNDLE_IDENTIFIER`, `BUNDLE_DISPLAY_NAME`; build configs en `pbxproj`; schemes `<flavorName>.xcscheme`.
+- ⚠️ JornaDay tiene el Android editado a mano para **compartir** id (Firebase único) — eso NO es la base; la base usa sufijo por flavor.
+- Hoy (antes de esto) solo había "entornos por código" (entry points + `AppEnvironment`), sin flavors nativos. Flutter local: 3.44.8, Android Kotlin DSL.
+- Implementado: entidad `Flavor` (`project_config.dart`), prompt (`cli_controller.dart`), preview de bundle IDs en el resumen, inyección Android (`configureFlavors` en `file_system_datasource.dart`, llamado desde `project_repository_impl.dart` tras `flutter create`). **Pendiente: iOS + entry points/launch.json + verificación.**
 
 ### 2. Bugs al actualizar
 Al hacer `vgv -u` había bugs. Revisar el flujo de update en `lib/vgv_cli.dart` (`_updateCLI`, `_checkForUpdates`, `_showUpdateProgress`) y `version_checker.dart`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,119 @@
+# CLAUDE.md
+
+Contexto del proyecto para Claude Code. Este archivo se **actualiza y commitea** a medida que agregamos features/fixes, para no perder contexto entre sesiones (aprendimos por las malas: se perdió ~1 mes de trabajo local no pusheado cuando se dañó la placa de la laptop).
+
+---
+
+## Qué es este proyecto
+
+`vgv_cli` es una **CLI en Dart** para generar proyectos Flutter production-ready y **evitar el boilerplate** de configurar todo a mano cada vez. La idea es generar un proyecto ya armado con la forma en la que el autor suele trabajar:
+
+- **BLoC + Freezed** para state management (estados inmutables)
+- **intl_utils** para traducciones (estilo claves como `jornaDay`) — de hecho **JornaDay se creó con este CLI**
+- **Clean Architecture** por capas (domain / data / presentation)
+- **GoRouter** para navegación
+- **bundleID configurado de una** para Android e iOS (y la plataforma que sea) al momento de crear la app
+- Entornos **dev / staging / production** listos
+- Config de VS Code (launch configs)
+
+Publicado en pub.dev como `vgv_cli`. Comando: `vgv`.
+
+- Repo: https://github.com/victorsdd01/vgv_cli
+- Autor: Victor Gonzalez (victorsdd01)
+
+---
+
+## Convenciones de trabajo (IMPORTANTE)
+
+- **Rama de trabajo: `develop`.** Trabajamos y commiteamos aquí.
+- **Commitear seguido** para no perder cambios (regla nacida de perder trabajo local).
+- **Mantener este `CLAUDE.md` actualizado**: cada vez que agregamos algo o arreglamos un bug, actualizamos la sección correspondiente y commiteamos.
+- Idioma de trabajo con el autor: **español**.
+
+---
+
+## Arquitectura del CLI (Clean Architecture)
+
+El CLI mismo está estructurado en capas dentro de `lib/`:
+
+| Capa | Ubicación | Responsabilidad |
+|------|-----------|-----------------|
+| **Entry** | `bin/vgv.dart` → `lib/vgv_cli.dart` | Parseo de args (`args`), help/version/update, dry-run, orquestación |
+| **Presentation** | `lib/presentation/controllers/cli_controller.dart` | UI interactiva (paquete `interact`), modo por flags, resumen de config |
+| **Domain** | `lib/domain/` | `entities/project_config.dart` (entidad + enums), `usecases/` (crear + validar), `repositories/project_repository.dart` (interfaz) |
+| **Data** | `lib/data/` | `repositories/project_repository_impl.dart`, `datasources/file_system_datasource.dart`, `datasources/flutter_command_datasource.dart` |
+| **Core** | `lib/core/` | DI manual (`di/dependency_injection.dart`), `utils/version_checker.dart`, `utils/ansi_colors.dart`, y el sistema de **templates** |
+
+### Sistema de templates (el corazón de la generación)
+
+- `lib/core/templates/template_contents.dart` — **~3600 líneas**: el contenido (como strings) de todos los archivos que se generan en el proyecto Flutter destino.
+- `lib/core/templates/template_generator.dart` — orquesta la escritura de esos contenidos.
+- `lib/core/templates/blocs/` — **proyecto Flutter completo de referencia** que sirve de base de las plantillas (features `auth`, `home`, `settings`, con capas domain/data/presentation, l10n, theme, routes, config de entornos, etc.).
+
+> Nota: hay artefactos de build commiteados en `lib/core/templates/blocs/build/` que probablemente no deberían estar versionados (candidato a limpieza).
+
+---
+
+## Entidad de configuración
+
+`ProjectConfig` (`lib/domain/entities/project_config.dart`) con enums:
+- `StateManagementType`: `bloc`, `provider`, `none`
+- `ArchitectureType`: `cleanArchitecture`, `mvvm`
+- `PlatformType`: `mobile`, `web`, `desktop`
+- `MobilePlatform`: `android`, `ios`, `both`
+- `DesktopPlatform`: `windows`, `macos`, `linux`, `all`, `custom` (+ `CustomDesktopPlatforms`)
+
+Validaciones (regex):
+- Nombre proyecto: `^[a-z][a-z0-9_]*$`
+- Organización: `^[a-z][a-z0-9._]*[a-z0-9]$`
+
+> Hoy el flujo interactivo **fija** `bloc` + `cleanArchitecture` + `goRouter` + `freezed` (no se preguntan todavía), aunque los enums soportan más opciones.
+
+---
+
+## Comandos / modos de uso
+
+```bash
+vgv                         # modo interactivo (prompts guiados)
+vgv -q -n my_app            # quick mode con defaults
+vgv -n my_app --org com.x   # con organización
+vgv -n my_app -o ~/proj     # directorio de salida
+vgv -n my_app --no-git      # sin git init
+vgv --dry-run -n my_app     # preview sin crear archivos
+vgv -h                      # help
+vgv -v                      # versión + check de updates
+vgv -u                      # auto-update (reinstala desde git)
+```
+
+Flags: `--help/-h`, `--version/-v`, `--update/-u`, `--quick/-q`, `--name/-n`, `--org`, `--output/-o`, `--no-git`, `--dry-run`.
+
+---
+
+## Stack del CLI
+
+- Dart SDK `>=3.7.0 <4.0.0`
+- Deps: `args`, `path`, `http`, `interact`
+- Dev: `lints`, `test`
+- Tests en `test/` (3 archivos: validate config, version checker, project config)
+- CI: `.github/workflows/auto-version-bump.yml` (bump automático de versión con `[skip ci]` para evitar loops)
+
+---
+
+## Roadmap / trabajo en curso
+
+### 1. Mejorar la UI de terminal (EN CURSO — primer paso)
+Objetivo: interfaz estilo **Mason CLI** / **Inquirer.js** — selecciones múltiples más bonitas, prompts más pulidos. Hoy se usa el paquete `interact` en `cli_controller.dart` (`Select`, `MultiSelect`, `Confirm`, `Spinner`, `Input`). Evaluar mejoras dentro de `interact` o alternativas.
+
+### 2. Bugs al actualizar
+Al hacer `vgv -u` había bugs. Revisar el flujo de update en `lib/vgv_cli.dart` (`_updateCLI`, `_checkForUpdates`, `_showUpdateProgress`) y `version_checker.dart`.
+
+### Ideas / features futuras
+- Preguntar en interactivo por state management / arquitectura (ya soportado en enums).
+- Limpiar artefactos de build versionados en `templates/blocs/build/`.
+- Alinear docs (`USAGE.md` menciona Cubit/Provider/MVVM que el flujo actual no expone).
+
+---
+
+## Historial de sesiones
+
+- **2026-08-07**: Máquina restaurada (placa reemplazada). Repo re-clonado limpio; se confirmó pérdida de ~1 mes de cambios locales no pusheados. Último commit real del proyecto: 2026-03-08 (v1.10.49). Se creó este `CLAUDE.md`. Se decidió trabajar en `develop`. Próximo paso: mejorar UI de terminal estilo Mason/Inquirer + arreglar bugs de update.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,14 @@ Análisis exhaustivo del CLI (2026-08-07). Arreglados:
 - **P2** Android `resValues` (ver Parte 5).
 - **P3** regex de org aceptaba puntos consecutivos (`com..x`) → corregida; `compareVersions` podía lanzar `FormatException` → parseo defensivo; `getLatestCLIVersion` sin timeout → timeout 10s.
 
-Pendientes (menor prioridad, ver #9): reporte de éxito engañoso cuando build_runner/l10n/pods fallan en silencio (P2); use cases de dominio (`CreateProjectUseCase`/`ValidateProjectConfigUseCase`) nunca se invocan → sin pre-check limpio de "flutter no instalado" (P2); barra de progreso de update falsa (cosmético); exit code 0 en fallos de validación; flags ignoradas fuera de flag-mode.
+También arreglados en una 2ª pasada:
+- **P2** reporte de éxito engañoso → `runBuildRunner`/`generateLocalizationFiles` ahora devuelven bool; `createProject` retorna `List<String>` de warnings y el CLI los muestra (ya no dice "success" a secas si falló codegen/l10n).
+- **P2** sin pre-check de Flutter → el controller llama `isFlutterInstalled()` antes de generar y aborta con mensaje claro.
+- **P3** barra de progreso falsa en `vgv -u` (imprimía "All steps completed" ANTES del `activate` real) → reemplazada por estado honesto.
+
+Verificado end-to-end con el CLI corregido (proyecto `verify_app` regenerado): git init OK, pubspec bien formado, `✓ app-dev-debug.apk`.
+
+Pendientes menores (para decidir con el usuario): use cases de dominio (`CreateProjectUseCase`/`ValidateProjectConfigUseCase`) siguen sin invocarse (código muerto — el pre-check se replicó en el controller); exit code 0 en fallos de validación (CI no los detecta); flags como `-o`/`--org` sueltas (sin `-n`/`-q`) se ignoran y cae a interactivo; `VersionChecker._latestVersions` hardcodeado y no usado por `addDependencies` (fuente de verdad duplicada).
 
 ### 2. Bugs al actualizar
 Al hacer `vgv -u` había bugs. Revisar el flujo de update en `lib/vgv_cli.dart` (`_updateCLI`, `_checkForUpdates`, `_showUpdateProgress`) y `version_checker.dart`.
@@ -168,4 +175,5 @@ El `[skip ci]` del fix `977bd56` (para cortar el loop infinito del bump) tambié
 
 ## Historial de sesiones
 
-- **2026-08-07**: Máquina restaurada (placa reemplazada). Repo re-clonado limpio; se confirmó pérdida de ~1 mes de cambios locales no pusheados. Último commit real del proyecto: 2026-03-08 (v1.10.49). Se creó este `CLAUDE.md`. Se decidió trabajar en `develop`. Próximo paso: mejorar UI de terminal estilo Mason/Inquirer + arreglar bugs de update.
+- **2026-08-07**: Máquina restaurada (placa reemplazada). Repo re-clonado limpio; se confirmó pérdida de ~1 mes de cambios locales no pusheados. Último commit real del proyecto: 2026-03-08 (v1.10.49). Se creó este `CLAUDE.md`. Se decidió trabajar en `develop`.
+- **2026-08-07 (sesión larga)**: Trabajo en `develop`, **commits locales sin push** (el usuario revisa el diff `develop` vs `main` al volver). Logrado: (1) UI migrada a `mason_logger`; (2) **flavors nativos completos** dev/staging/prod (Android productFlavors + iOS pbxproj/schemes/xcconfig + entry points + launch.json), prompt para elegir cuáles, preview de bundle IDs, verificado con builds reales Android+iOS; (3) **fix de update/versión** (fuente única horneada + canal git); (4) **bug hunt** con ~10 fixes P1/P2/P3. Todo con `analyze` limpio y 31 tests pasando. Commits `26495a0`..`b01c2a4`. Identidad git local: `victorsdd`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,14 @@ Al hacer `vgv -u` había bugs. Revisar el flujo de update en `lib/vgv_cli.dart` 
 
 El `[skip ci]` del fix `977bd56` (para cortar el loop infinito del bump) también evitó que se tagueara/publicara el bump final → por eso 1.10.49 quedó sin tag/release. `getLatestCLIVersion()` lee releases (1.10.48) y `getLatestCLIVersionFromGit()` lee main pubspec (1.10.49) → inconsistencia. Además `getCurrentVersion()` lee primero `~/.vgv_version` (caché que queda viejo y tapa la versión real) y su fallback "dev mode" lee el pubspec del **CWD** (no el del CLI). Al actualizar, guarda la versión *esperada del remoto*, no la *realmente instalada*.
 
-**Fix pendiente (2 frentes):** (a) código — elegir canal canónico único + versión horneada (constante Dart generada, estilo Mason) y eliminar el `~/.vgv_version` frágil; (b) CI — que el bump final sí genere su tag/release sin reactivar el loop.
+**Fix aplicado (✅):**
+- **Versión horneada como fuente única**: `lib/src/version.dart` con `const packageVersion` (generado por `tool/generate_version.dart` desde pubspec). `VersionChecker.getCurrentVersion()` ahora devuelve esa constante. Eliminado el frágil `~/.vgv_version` (que quedaba viejo y tapaba la versión real) y el fallback al pubspec del CWD.
+- **Canal canónico único**: `getLatestCLIVersionAny()` lee el `pubspec` de `main` (lo que instala `vgv -u`); GitHub Releases queda solo como fallback. Se acabó la discrepancia releases vs main.
+- **CI**: el workflow `auto-version-bump.yml` ahora sincroniza `lib/src/version.dart` (via sed) al hacer bump y lo incluye en el commit del bump.
+- Limpieza en `vgv_cli.dart`: quitado `_initializeVersionFile`, los `saveInstalledVersion` y el fallback muerto `1.0.0`.
+- Verificado: `vgv -v` → current 1.10.39 (horneada) / latest 1.10.49 (git main). 31 tests pasan.
+
+**Nota (lag de tag/release, no crítico):** el job de release taguea la versión actual del pubspec en el siguiente push que NO sea de bump; por eso el último tag/release (v1.10.48) va una versión detrás del pubspec de main (1.10.49). Ya no afecta al CLI porque "latest" se lee de main, no de releases. `develop` (1.10.39) está detrás de `main` (1.10.49) — otro efecto del auto-bump en main sin merge-back a develop.
 
 ### Ideas / features futuras
 - Preguntar en interactivo por state management / arquitectura (ya soportado en enums).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,9 @@ Flags: `--help/-h`, `--version/-v`, `--update/-u`, `--quick/-q`, `--name/-n`, `-
 ## Stack del CLI
 
 - Dart SDK `>=3.7.0 <4.0.0`
-- Deps: `args`, `path`, `http`, `interact`
+- Deps: `args`, `path`, `http`, `mason_logger` (UI de terminal estilo Mason)
 - Dev: `lints`, `test`
+- **UI interactiva**: `cli_controller.dart` usa `mason_logger` (`prompt`, `confirm`, `chooseOne`, `chooseAny` multi-select ◉/◯, `progress`). Los prompts requieren un TTY real (no se pueden verificar con stdout redirigido).
 - Tests en `test/` (3 archivos: validate config, version checker, project config)
 - CI: `.github/workflows/auto-version-bump.yml` (bump automático de versión con `[skip ci]` para evitar loops)
 
@@ -101,8 +102,11 @@ Flags: `--help/-h`, `--version/-v`, `--update/-u`, `--quick/-q`, `--name/-n`, `-
 
 ## Roadmap / trabajo en curso
 
-### 1. Mejorar la UI de terminal (EN CURSO — primer paso)
-Objetivo: interfaz estilo **Mason CLI** / **Inquirer.js** — selecciones múltiples más bonitas, prompts más pulidos. Hoy se usa el paquete `interact` en `cli_controller.dart` (`Select`, `MultiSelect`, `Confirm`, `Spinner`, `Input`). Evaluar mejoras dentro de `interact` o alternativas.
+### 1. Mejorar la UI de terminal (✅ HECHO)
+Migrado de `interact` a **`mason_logger`** (el logger de Mason CLI, hecho por Very Good Ventures — mismo ecosistema que VGV). `cli_controller.dart` ahora usa `chooseOne`/`chooseAny` (multi-select estilo inquirer), `prompt`, `confirm` y `progress`. `interact` removido.
+
+### 1.b Flavors nativos + entry points (EN CURSO — feature grande)
+Configurar **flavors nativos reales** (Android `productFlavors` en `build.gradle.kts` + iOS build configs/schemes en `pbxproj`) con **bundleID distinto por entorno** (dev/staging/production), app name por flavor, y entry points cableados con `--flavor`. **Preguntar en la creación qué flavors quiere** (los 3 o un subconjunto). Hoy solo hay "entornos por código" (entry points main_dev/staging/production + `AppEnvironment`), NO flavors nativos. Flutter local: 3.44.8, Android usa Kotlin DSL (`build.gradle.kts`).
 
 ### 2. Bugs al actualizar
 Al hacer `vgv -u` había bugs. Revisar el flujo de update en `lib/vgv_cli.dart` (`_updateCLI`, `_checkForUpdates`, `_showUpdateProgress`) y `version_checker.dart`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,8 @@ Configurar **flavors nativos reales** (Android `productFlavors` en `build.gradle
 - Hoy (antes de esto) solo había "entornos por código" (entry points + `AppEnvironment`), sin flavors nativos. Flutter local: 3.44.8, Android Kotlin DSL.
 - Implementado: entidad `Flavor` (`project_config.dart`), prompt (`cli_controller.dart`), preview de bundle IDs en el resumen, inyección Android + **iOS** (`configureFlavors` en `file_system_datasource.dart`, llamado desde `project_repository_impl.dart` tras `flutter create`).
   - iOS: genera xcconfig `<BuildType>-<flavor>.xcconfig` (con `FLUTTER_TARGET`, `PRODUCT_BUNDLE_IDENTIFIER`, `BUNDLE_DISPLAY_NAME`), duplica las build configs Debug/Release/Profile → `-<flavor>` en las 3 config lists del `pbxproj` (bundle id por flavor solo en el target Runner), y crea schemes `<flavor>.xcscheme`. Ids de pbxproj generados con prefijo `FF` (sin colisión con flutter). **Validado con `xcodebuild -list`** (reconoce configs y schemes).
-  - **Pendiente: entry points/launch.json/run wiring (Parte 4) + verificación build real (Parte 5).**
+  - Parte 4 (✅): `launch.json` flavor-aware (una config por flavor×modo con `"args":["--flavor",...]`), poda de entry points `main_<f>.dart` no seleccionados, y "Next steps" del CLI con `flutter run --flavor`.
+  - **Pendiente: verificación build real (Parte 5).**
 
 ### 2. Bugs al actualizar
 Al hacer `vgv -u` había bugs. Revisar el flujo de update en `lib/vgv_cli.dart` (`_updateCLI`, `_checkForUpdates`, `_showUpdateProgress`) y `version_checker.dart`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,9 @@ Configurar **flavors nativos reales** (Android `productFlavors` en `build.gradle
 - iOS: xcconfig `Debug/Release/Profile-<flavorName>.xcconfig` con `FLUTTER_TARGET`, `PRODUCT_BUNDLE_IDENTIFIER`, `BUNDLE_DISPLAY_NAME`; build configs en `pbxproj`; schemes `<flavorName>.xcscheme`.
 - ⚠️ JornaDay tiene el Android editado a mano para **compartir** id (Firebase único) — eso NO es la base; la base usa sufijo por flavor.
 - Hoy (antes de esto) solo había "entornos por código" (entry points + `AppEnvironment`), sin flavors nativos. Flutter local: 3.44.8, Android Kotlin DSL.
-- Implementado: entidad `Flavor` (`project_config.dart`), prompt (`cli_controller.dart`), preview de bundle IDs en el resumen, inyección Android (`configureFlavors` en `file_system_datasource.dart`, llamado desde `project_repository_impl.dart` tras `flutter create`). **Pendiente: iOS + entry points/launch.json + verificación.**
+- Implementado: entidad `Flavor` (`project_config.dart`), prompt (`cli_controller.dart`), preview de bundle IDs en el resumen, inyección Android + **iOS** (`configureFlavors` en `file_system_datasource.dart`, llamado desde `project_repository_impl.dart` tras `flutter create`).
+  - iOS: genera xcconfig `<BuildType>-<flavor>.xcconfig` (con `FLUTTER_TARGET`, `PRODUCT_BUNDLE_IDENTIFIER`, `BUNDLE_DISPLAY_NAME`), duplica las build configs Debug/Release/Profile → `-<flavor>` en las 3 config lists del `pbxproj` (bundle id por flavor solo en el target Runner), y crea schemes `<flavor>.xcscheme`. Ids de pbxproj generados con prefijo `FF` (sin colisión con flutter). **Validado con `xcodebuild -list`** (reconoce configs y schemes).
+  - **Pendiente: entry points/launch.json/run wiring (Parte 4) + verificación build real (Parte 5).**
 
 ### 2. Bugs al actualizar
 Al hacer `vgv -u` había bugs. Revisar el flujo de update en `lib/vgv_cli.dart` (`_updateCLI`, `_checkForUpdates`, `_showUpdateProgress`) y `version_checker.dart`.

--- a/lib/core/utils/version_checker.dart
+++ b/lib/core/utils/version_checker.dart
@@ -102,7 +102,9 @@ class VersionChecker {
   /// Get the latest CLI version from GitHub releases
   static Future<String?> getLatestCLIVersion() async {
     try {
-      final response = await http.get(Uri.parse(_githubApiUrl));
+      final response = await http
+          .get(Uri.parse(_githubApiUrl))
+          .timeout(const Duration(seconds: 10));
 
       if (response.statusCode == 200) {
         final dynamic data;
@@ -171,8 +173,18 @@ class VersionChecker {
   /// Compare two version strings
   /// Returns: -1 if version1 < version2, 0 if equal, 1 if version1 > version2
   static int compareVersions(String version1, String version2) {
-    final parts1 = version1.split('.').map(int.parse).toList();
-    final parts2 = version2.split('.').map(int.parse).toList();
+    // Strip any pre-release/build metadata (e.g. 1.2.3-beta+1) and parse
+    // defensively so a malformed tag never throws a FormatException.
+    List<int> parse(String v) => v
+        .split('+')
+        .first
+        .split('-')
+        .first
+        .split('.')
+        .map((p) => int.tryParse(p) ?? 0)
+        .toList();
+    final parts1 = parse(version1);
+    final parts2 = parse(version2);
     
     // Pad with zeros if needed
     while (parts1.length < parts2.length) {

--- a/lib/core/utils/version_checker.dart
+++ b/lib/core/utils/version_checker.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:http/http.dart' as http;
-import 'package:path/path.dart' as path;
+import '../../src/version.dart';
 
 /// Utility class to check for the latest versions of Flutter packages
 class VersionChecker {
@@ -20,84 +20,12 @@ class VersionChecker {
 
   static const String _githubApiUrl = 'https://api.github.com/repos/victorsdd01/vgv_cli/releases/latest';
   
-  /// Get the path to the version file
-  static String _getVersionFilePath() {
-    final homeDir = Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'] ?? '';
-    if (homeDir.isNotEmpty) {
-      return path.join(homeDir, '.vgv_version');
-    }
-    // Fallback to current directory
-    return path.join(Directory.current.path, '.vgv_version');
-  }
-  
-  /// Save the installed version to a file
-  static void saveInstalledVersion(String version) {
-    try {
-      final versionFile = File(_getVersionFilePath());
-      versionFile.writeAsStringSync(version);
-    } catch (e) {
-      // Silently fail - not critical
-    }
-  }
-  
-  /// Get the installed version from the version file
-  static String? getInstalledVersionFromFile() {
-    try {
-      final versionFile = File(_getVersionFilePath());
-      if (versionFile.existsSync()) {
-        final version = versionFile.readAsStringSync().trim();
-        if (version.isNotEmpty && RegExp(r'^\d+\.\d+\.\d+$').hasMatch(version)) {
-          return version;
-        }
-      }
-    } catch (e) {
-      // Silently fail
-    }
-    return null;
-  }
-  
-  /// Get current version from saved file or dart pub global list
-  static String getCurrentVersion() {
-    // 1. Try saved version file (most reliable for installed CLI)
-    final savedVersion = getInstalledVersionFromFile();
-    if (savedVersion != null) {
-      return savedVersion;
-    }
-
-    // 2. Try dart pub global list
-    try {
-      final result = Process.runSync(
-        'dart',
-        ['pub', 'global', 'list'],
-        runInShell: true,
-      );
-      if (result.exitCode == 0) {
-        final versionMatch = RegExp(r'vgv_cli\s+(\d+\.\d+\.\d+)')
-            .firstMatch(result.stdout.toString());
-        if (versionMatch != null) {
-          final version = versionMatch.group(1)!;
-          saveInstalledVersion(version);
-          return version;
-        }
-      }
-    } catch (_) {}
-
-    // 3. Try local pubspec.yaml (development mode)
-    try {
-      final localPubspec = File(path.join(Directory.current.path, 'pubspec.yaml'));
-      if (localPubspec.existsSync()) {
-        final content = localPubspec.readAsStringSync();
-        if (content.contains('name: vgv_cli')) {
-          final versionMatch = RegExp(r'version:\s*(\d+\.\d+\.\d+)').firstMatch(content);
-          if (versionMatch != null) {
-            return versionMatch.group(1)!;
-          }
-        }
-      }
-    } catch (_) {}
-
-    return '1.0.0';
-  }
+  /// The current CLI version — the single source of truth, baked at build
+  /// time from `pubspec.yaml` (see `tool/generate_version.dart`).
+  ///
+  /// Reading `pubspec.yaml` at runtime is unreliable for a globally activated
+  /// package, so we rely on the generated [packageVersion] constant instead.
+  static String getCurrentVersion() => packageVersion;
   
   /// Get version from Git synchronously (for fallback when pubspec.yaml not found locally)
   static String? getLatestCLIVersionFromGitSync() {
@@ -219,20 +147,17 @@ class VersionChecker {
     return null;
   }
   
-  /// Get the latest CLI version (tries releases first, then Git, returns the newest)
+  /// Get the latest CLI version.
+  ///
+  /// Canonical source is the `main` branch `pubspec.yaml` — that is exactly
+  /// what `vgv --update` installs (`dart pub global activate --source git`),
+  /// so current-vs-latest comparisons stay consistent. GitHub Releases are
+  /// only a fallback when `main` cannot be reached, since the release/tag
+  /// pipeline can lag one version behind `main`.
   static Future<String?> getLatestCLIVersionAny() async {
-    final releaseVersion = await getLatestCLIVersion();
     final gitVersion = await getLatestCLIVersionFromGit();
-    
-    // If we have both versions, return the newest one
-    if (releaseVersion != null && gitVersion != null) {
-      return compareVersions(releaseVersion, gitVersion) >= 0 
-          ? releaseVersion 
-          : gitVersion;
-    }
-    
-    // If we only have one, return it
-    return releaseVersion ?? gitVersion;
+    if (gitVersion != null) return gitVersion;
+    return getLatestCLIVersion();
   }
   
   /// Check if an update is available

--- a/lib/data/datasources/file_system_datasource.dart
+++ b/lib/data/datasources/file_system_datasource.dart
@@ -17,7 +17,7 @@ abstract class FileSystemDataSource {
   Future<void> createBuildYaml(String projectName);
   Future<void> createInternationalization(String projectName);
   Future<void> ensureCleanArchitectureFiles(String projectName);
-  Future<void> createVSCodeLaunchConfig(String projectName);
+  Future<void> createVSCodeLaunchConfig(String projectName, List<Flavor> flavors);
   Future<void> createGitIgnore(String projectName);
 
   /// Configures native build flavors (Android product flavors + iOS build
@@ -1851,7 +1851,16 @@ class AppLocalizationsSetup {
   }
 
   @override
-  Future<void> createVSCodeLaunchConfig(String projectName) async {
+  Future<void> createVSCodeLaunchConfig(String projectName, List<Flavor> flavors) async {
+    // Prune entry points for flavors that were NOT selected.
+    for (final flavor in Flavor.values) {
+      if (!flavors.contains(flavor)) {
+        final entry =
+            File(path.join(projectName, 'lib', 'main_${flavor.entryPoint}.dart'));
+        if (entry.existsSync()) entry.deleteSync();
+      }
+    }
+
     final vscodeDir = Directory(path.join(projectName, '.vscode'));
     if (!vscodeDir.existsSync()) {
       vscodeDir.createSync(recursive: true);
@@ -1882,76 +1891,32 @@ class AppLocalizationsSetup {
     final launchJsonPath = path.join(projectName, '.vscode', 'launch.json');
     final launchJsonFile = File(launchJsonPath);
     
+    final entries = <String>[];
+    for (final flavor in flavors) {
+      for (final mode in const ['debug', 'profile', 'release']) {
+        final suffix = mode == 'debug'
+            ? ''
+            : ' - ${mode[0].toUpperCase()}${mode.substring(1)}';
+        final name = '$projectName (${flavor.displayName})$suffix';
+        entries.add('''    {
+      "name": "$name",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main_${flavor.entryPoint}.dart",
+      "args": ["--flavor", "${flavor.flavorName}"],
+      "flutterMode": "$mode"
+    }''');
+      }
+    }
+
     final content = '''{
   "version": "0.2.0",
   "configurations": [
-    {
-      "name": "$projectName (Dev)",
-      "request": "launch",
-      "type": "dart",
-      "program": "lib/main_dev.dart",
-      "flutterMode": "debug"
-    },
-    {
-      "name": "$projectName (Dev) - Profile",
-      "request": "launch",
-      "type": "dart",
-      "program": "lib/main_dev.dart",
-      "flutterMode": "profile"
-    },
-    {
-      "name": "$projectName (Dev) - Release",
-      "request": "launch",
-      "type": "dart",
-      "program": "lib/main_dev.dart",
-      "flutterMode": "release"
-    },
-    {
-      "name": "$projectName (Staging)",
-      "request": "launch",
-      "type": "dart",
-      "program": "lib/main_staging.dart",
-      "flutterMode": "debug"
-    },
-    {
-      "name": "$projectName (Staging) - Profile",
-      "request": "launch",
-      "type": "dart",
-      "program": "lib/main_staging.dart",
-      "flutterMode": "profile"
-    },
-    {
-      "name": "$projectName (Staging) - Release",
-      "request": "launch",
-      "type": "dart",
-      "program": "lib/main_staging.dart",
-      "flutterMode": "release"
-    },
-    {
-      "name": "$projectName (Production)",
-      "request": "launch",
-      "type": "dart",
-      "program": "lib/main_production.dart",
-      "flutterMode": "debug"
-    },
-    {
-      "name": "$projectName (Production) - Profile",
-      "request": "launch",
-      "type": "dart",
-      "program": "lib/main_production.dart",
-      "flutterMode": "profile"
-    },
-    {
-      "name": "$projectName (Production) - Release",
-      "request": "launch",
-      "type": "dart",
-      "program": "lib/main_production.dart",
-      "flutterMode": "release"
-    }
+${entries.join(',\n')}
   ]
 }
 ''';
-    
+
     launchJsonFile.writeAsStringSync(content);
   }
 

--- a/lib/data/datasources/file_system_datasource.dart
+++ b/lib/data/datasources/file_system_datasource.dart
@@ -2060,7 +2060,7 @@ key.properties
   Future<void> configureFlavors(ProjectConfig config) async {
     if (config.flavors.isEmpty) return;
     await _configureAndroidFlavors(config);
-    // iOS flavor configuration is added in a later step.
+    await _configureIosFlavors(config);
   }
 
   /// Converts a package name into a human friendly app name.
@@ -2200,6 +2200,336 @@ key.properties
       'android:label="@string/app_name"',
     );
     manifest.writeAsStringSync(content);
+  }
+
+  // ── iOS ────────────────────────────────────────────────────────────────
+
+  /// Configures iOS flavors by adding per-flavor xcconfig files, duplicating
+  /// the Debug/Release/Profile build configurations into
+  /// `<BuildType>-<flavor>` variants (with a distinct bundle id) inside
+  /// `project.pbxproj`, and generating a shared scheme per flavor.
+  Future<void> _configureIosFlavors(ProjectConfig config) async {
+    final iosDir = Directory(path.join(config.projectName, 'ios'));
+    final pbxFile =
+        File(path.join(iosDir.path, 'Runner.xcodeproj', 'project.pbxproj'));
+    // iOS platform was not generated for this project.
+    if (!pbxFile.existsSync()) return;
+
+    var pbx = pbxFile.readAsStringSync();
+    final firstFlavor = config.flavors.first.flavorName;
+    if (pbx.contains('/* Debug-$firstFlavor */')) return; // idempotent
+
+    final appName = _humanizeName(config.projectName);
+    final baseBundleId = _iosBaseBundleId(pbx) ??
+        '${config.organizationName}.${config.projectName}';
+    const buildTypes = ['Debug', 'Release', 'Profile'];
+
+    var seed = 0;
+    String nextId() => _pbxId(seed++);
+
+    // 1) Create xcconfig files + PBXFileReference / group entries.
+    final flutterDir = Directory(path.join(iosDir.path, 'Flutter'));
+    final xcconfigRefIds = <String, String>{}; // "Debug-dev" -> fileRef id
+    final fileRefLines = <String>[];
+    final groupChildLines = <String>[];
+    for (final flavor in config.flavors) {
+      for (final buildType in buildTypes) {
+        final cfgName = '$buildType-${flavor.flavorName}';
+        File(path.join(flutterDir.path, '$cfgName.xcconfig')).writeAsStringSync(
+          _iosXcconfigContent(buildType, flavor, appName, baseBundleId),
+        );
+        final refId = nextId();
+        xcconfigRefIds[cfgName] = refId;
+        fileRefLines.add(
+          '\t\t$refId /* $cfgName.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "$cfgName.xcconfig"; path = "Flutter/$cfgName.xcconfig"; sourceTree = "<group>"; };',
+        );
+        groupChildLines.add('\t\t\t\t$refId /* $cfgName.xcconfig */,');
+      }
+    }
+
+    pbx = pbx.replaceFirst(
+      '/* End PBXFileReference section */',
+      '${fileRefLines.join('\n')}\n/* End PBXFileReference section */',
+    );
+    pbx = pbx.replaceFirstMapped(
+      RegExp(r'\n\t\t\t\t9740EEB31CF90195004384FC /\* Generated\.xcconfig \*/,'),
+      (m) => '${m.group(0)}\n${groupChildLines.join('\n')}',
+    );
+
+    // 2) Duplicate build configurations per flavor across the config lists.
+    const lists = [
+      'Build configuration list for PBXNativeTarget "RunnerTests"',
+      'Build configuration list for PBXProject "Runner"',
+      'Build configuration list for PBXNativeTarget "Runner"',
+    ];
+    final newBlocks = <String>[];
+    for (final listComment in lists) {
+      final isRunnerTarget = listComment == lists.last;
+      final members = _configListMembers(pbx, listComment);
+      final newMemberLines = <String>[];
+      for (final memberId in members) {
+        final block = _xcBuildConfigBlock(pbx, memberId);
+        if (block.isEmpty) continue;
+        final buildType = _configName(block);
+        for (final flavor in config.flavors) {
+          final newId = nextId();
+          final cfgName = '$buildType-${flavor.flavorName}';
+          var clone = block
+              .replaceFirst(
+                '$memberId /* $buildType */',
+                '$newId /* $cfgName */',
+              )
+              .replaceFirst(
+                RegExp('name = "?$buildType"?;'),
+                'name = "$cfgName";',
+              );
+          if (isRunnerTarget) {
+            final refId = xcconfigRefIds[cfgName]!;
+            if (clone.contains('baseConfigurationReference')) {
+              clone = clone.replaceFirst(
+                RegExp(r'baseConfigurationReference = [0-9A-F]{24} /\* [^*]+\.xcconfig \*/;'),
+                'baseConfigurationReference = $refId /* $cfgName.xcconfig */;',
+              );
+            } else {
+              clone = clone.replaceFirst(
+                'isa = XCBuildConfiguration;',
+                'isa = XCBuildConfiguration;\n\t\t\tbaseConfigurationReference = $refId /* $cfgName.xcconfig */;',
+              );
+            }
+            clone = clone.replaceFirst(
+              RegExp(r'PRODUCT_BUNDLE_IDENTIFIER = "?[^";]+"?;'),
+              'PRODUCT_BUNDLE_IDENTIFIER = "${flavor.bundleId(baseBundleId)}";',
+            );
+          }
+          newBlocks.add(clone);
+          newMemberLines.add('\t\t\t\t$newId /* $cfgName */,');
+        }
+      }
+      pbx = _appendToConfigList(pbx, listComment, newMemberLines.join('\n'));
+    }
+
+    pbx = pbx.replaceFirst(
+      '/* End XCBuildConfiguration section */',
+      '${newBlocks.join('\n')}\n/* End XCBuildConfiguration section */',
+    );
+
+    pbxFile.writeAsStringSync(pbx);
+
+    // 3) Generate a shared scheme per flavor.
+    final schemesDir = Directory(
+      path.join(iosDir.path, 'Runner.xcodeproj', 'xcshareddata', 'xcschemes'),
+    );
+    schemesDir.createSync(recursive: true);
+    for (final flavor in config.flavors) {
+      File(path.join(schemesDir.path, '${flavor.flavorName}.xcscheme'))
+          .writeAsStringSync(_iosSchemeContent(flavor.flavorName));
+    }
+  }
+
+  /// Generates a deterministic, collision-free 24-char pbxproj object id.
+  /// The `FF` prefix guarantees no clash with `flutter create`'s ids.
+  String _pbxId(int seed) =>
+      'FF${seed.toRadixString(16).toUpperCase().padLeft(22, '0')}';
+
+  /// Reads the base (production) bundle id from the Runner target settings,
+  /// ignoring the RunnerTests identifier.
+  String? _iosBaseBundleId(String pbx) {
+    for (final m
+        in RegExp(r'PRODUCT_BUNDLE_IDENTIFIER = "?([^";]+)"?;').allMatches(pbx)) {
+      final value = m.group(1)!;
+      if (!value.contains('RunnerTests')) return value;
+    }
+    return null;
+  }
+
+  /// Returns the ordered member config ids of an XCConfigurationList block.
+  List<String> _configListMembers(String pbx, String listComment) {
+    final idx = pbx.indexOf('/* $listComment */ = {');
+    if (idx == -1) return const [];
+    final bcStart = pbx.indexOf('buildConfigurations = (', idx);
+    final bcEnd = pbx.indexOf(');', bcStart);
+    final arr = pbx.substring(bcStart, bcEnd);
+    return RegExp(r'([0-9A-F]{24}) /\*')
+        .allMatches(arr)
+        .map((m) => m.group(1)!)
+        .toList();
+  }
+
+  /// Extracts a full XCBuildConfiguration block (including the closing `};`).
+  String _xcBuildConfigBlock(String pbx, String id) {
+    final start = pbx.indexOf('\t\t$id /* ');
+    if (start == -1) return '';
+    final end = pbx.indexOf('\n\t\t};', start);
+    if (end == -1) return '';
+    return '${pbx.substring(start, end)}\n\t\t};';
+  }
+
+  /// Reads the `name = ...;` of an XCBuildConfiguration block.
+  String _configName(String block) =>
+      RegExp(r'\bname = "?([A-Za-z]+)"?;').firstMatch(block)?.group(1) ?? '';
+
+  /// Appends member id lines before the closing of a config list array.
+  String _appendToConfigList(String pbx, String listComment, String lines) {
+    if (lines.isEmpty) return pbx;
+    final idx = pbx.indexOf('/* $listComment */ = {');
+    if (idx == -1) return pbx;
+    final bcStart = pbx.indexOf('buildConfigurations = (', idx);
+    final closeIdx = pbx.indexOf('\t\t\t);', bcStart);
+    if (closeIdx == -1) return pbx;
+    return '${pbx.substring(0, closeIdx)}$lines\n${pbx.substring(closeIdx)}';
+  }
+
+  String _iosXcconfigContent(
+    String buildType,
+    Flavor flavor,
+    String appName,
+    String baseBundleId,
+  ) {
+    final lower = buildType.toLowerCase();
+    return '#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.$lower-${flavor.flavorName}.xcconfig"\n'
+        '#include "Generated.xcconfig"\n'
+        'FLUTTER_TARGET=lib/main_${flavor.entryPoint}.dart\n'
+        'ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon\n'
+        'PRODUCT_BUNDLE_IDENTIFIER=${flavor.bundleId(baseBundleId)}\n'
+        'BUNDLE_DISPLAY_NAME=$appName${flavor.appNameSuffix}\n';
+  }
+
+  /// Builds a shared scheme for [flavorName] based on the default Runner
+  /// scheme, binding each action to the `<BuildType>-<flavor>` configuration.
+  String _iosSchemeContent(String flavorName) {
+    const template = r'''<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "/bin/sh &quot;$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh&quot; prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                     BuildableName = "Runner.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "331C8080294A63A400263BE5"
+               BuildableName = "RunnerTests.xctest"
+               BlueprintName = "RunnerTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Profile"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:Runner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>
+''';
+    return template
+        .replaceAll(
+          'buildConfiguration = "Debug"',
+          'buildConfiguration = "Debug-$flavorName"',
+        )
+        .replaceAll(
+          'buildConfiguration = "Profile"',
+          'buildConfiguration = "Profile-$flavorName"',
+        )
+        .replaceAll(
+          'buildConfiguration = "Release"',
+          'buildConfiguration = "Release-$flavorName"',
+        );
   }
 
 

--- a/lib/data/datasources/file_system_datasource.dart
+++ b/lib/data/datasources/file_system_datasource.dart
@@ -17,7 +17,7 @@ abstract class FileSystemDataSource {
   Future<void> createBuildYaml(String projectName);
   Future<void> createInternationalization(String projectName);
   Future<void> ensureCleanArchitectureFiles(String projectName);
-  Future<void> createVSCodeLaunchConfig(String projectName, List<Flavor> flavors);
+  Future<void> createVSCodeLaunchConfig(String projectName, List<Flavor> flavors, {bool nativeFlavors = true});
   Future<void> createGitIgnore(String projectName);
 
   /// Configures native build flavors (Android product flavors + iOS build
@@ -148,95 +148,39 @@ class FileSystemDataSourceImpl implements FileSystemDataSource {
       'intl_utils: ^2.8.7',
     ]);
 
+    // Insert our dependencies right after each section header, preserving the
+    // entries `flutter create` already wrote (flutter sdk, cupertino_icons,
+    // flutter_test, flutter_lints). The previous approach mis-detected the
+    // `flutter:` SDK dependency as the top-level `flutter:` section and pushed
+    // the SDK + cupertino_icons under dev_dependencies.
     final lines = pubspecContent.split('\n');
     final newLines = <String>[];
-    bool skipUntilNextSection = false;
     bool dependenciesAdded = false;
     bool devDependenciesAdded = false;
-    
-    for (int i = 0; i < lines.length; i++) {
-      final line = lines[i];
-      final trimmedLine = line.trim();
-      
-      if (trimmedLine == 'dependencies:') {
-        skipUntilNextSection = true;
-        if (!dependenciesAdded) {
-          newLines.add('dependencies:');
-          for (final dep in dependencies) {
-            newLines.add('  $dep');
-          }
-          newLines.add('');
-          dependenciesAdded = true;
-        }
-        continue;
-      }
-      
-      if (trimmedLine == 'dev_dependencies:') {
-        skipUntilNextSection = true;
-        if (!devDependenciesAdded) {
-          newLines.add('dev_dependencies:');
-          for (final dep in devDependencies) {
-            newLines.add('  $dep');
-          }
-          newLines.add('');
-          devDependenciesAdded = true;
-        }
-        continue;
-      }
-      
-      if (skipUntilNextSection) {
-        if (trimmedLine.isEmpty || trimmedLine.startsWith('  ') || trimmedLine.startsWith('    ') || trimmedLine.startsWith('#')) {
-          continue;
-        } else {
-          skipUntilNextSection = false;
-        }
-      }
-      
-      if (trimmedLine == 'flutter:' && !dependenciesAdded) {
-        newLines.add('dependencies:');
-        for (final dep in dependencies) {
-          newLines.add('  $dep');
-        }
-        newLines.add('');
-        dependenciesAdded = true;
-      }
-      
-      if (trimmedLine == 'flutter:' && dependenciesAdded && !devDependenciesAdded) {
-        newLines.add('dev_dependencies:');
-        for (final dep in devDependencies) {
-          newLines.add('  $dep');
-        }
-        newLines.add('');
-        devDependenciesAdded = true;
-      }
-      
+
+    for (final line in lines) {
       newLines.add(line);
-    }
-    
-    if (!dependenciesAdded) {
-      final flutterIndex = newLines.indexWhere((line) => line.trim() == 'flutter:');
-      if (flutterIndex != -1) {
-        newLines.insert(flutterIndex, '');
-        for (int i = dependencies.length - 1; i >= 0; i--) {
-          newLines.insert(flutterIndex, '  ${dependencies[i]}');
-        }
-        newLines.insert(flutterIndex, 'dependencies:');
+      if (line.trim() == 'dependencies:' && !dependenciesAdded) {
+        newLines.addAll(dependencies.map((dep) => '  $dep'));
         dependenciesAdded = true;
-      }
-    }
-    
-    if (!devDependenciesAdded && dependenciesAdded) {
-      final flutterIndex = newLines.indexWhere((line) => line.trim() == 'flutter:');
-      if (flutterIndex != -1) {
-        newLines.insert(flutterIndex, '');
-        for (int i = devDependencies.length - 1; i >= 0; i--) {
-          newLines.insert(flutterIndex, '  ${devDependencies[i]}');
-        }
-        newLines.insert(flutterIndex, 'dev_dependencies:');
+      } else if (line.trim() == 'dev_dependencies:' && !devDependenciesAdded) {
+        newLines.addAll(devDependencies.map((dep) => '  $dep'));
         devDependenciesAdded = true;
       }
     }
-    
+
+    // Fallbacks if a section was missing (unusual for `flutter create` output).
+    if (!dependenciesAdded) {
+      newLines
+        ..add('dependencies:')
+        ..addAll(dependencies.map((dep) => '  $dep'));
+    }
+    if (!devDependenciesAdded) {
+      newLines
+        ..add('dev_dependencies:')
+        ..addAll(devDependencies.map((dep) => '  $dep'));
+    }
+
     pubspecContent = newLines.join('\n');
 
     pubspecFile.writeAsStringSync(pubspecContent);
@@ -1851,7 +1795,7 @@ class AppLocalizationsSetup {
   }
 
   @override
-  Future<void> createVSCodeLaunchConfig(String projectName, List<Flavor> flavors) async {
+  Future<void> createVSCodeLaunchConfig(String projectName, List<Flavor> flavors, {bool nativeFlavors = true}) async {
     // Prune entry points for flavors that were NOT selected.
     for (final flavor in Flavor.values) {
       if (!flavors.contains(flavor)) {
@@ -1898,12 +1842,16 @@ class AppLocalizationsSetup {
             ? ''
             : ' - ${mode[0].toUpperCase()}${mode.substring(1)}';
         final name = '$projectName (${flavor.displayName})$suffix';
+        // `--flavor` only applies to native mobile targets; web and
+        // Windows/Linux desktop reject it, so omit the arg there.
+        final argsLine = nativeFlavors
+            ? '\n      "args": ["--flavor", "${flavor.flavorName}"],'
+            : '';
         entries.add('''    {
       "name": "$name",
       "request": "launch",
       "type": "dart",
-      "program": "lib/main_${flavor.entryPoint}.dart",
-      "args": ["--flavor", "${flavor.flavorName}"],
+      "program": "lib/main_${flavor.entryPoint}.dart",$argsLine
       "flutterMode": "$mode"
     }''');
       }

--- a/lib/data/datasources/file_system_datasource.dart
+++ b/lib/data/datasources/file_system_datasource.dart
@@ -19,6 +19,11 @@ abstract class FileSystemDataSource {
   Future<void> ensureCleanArchitectureFiles(String projectName);
   Future<void> createVSCodeLaunchConfig(String projectName);
   Future<void> createGitIgnore(String projectName);
+
+  /// Configures native build flavors (Android product flavors + iOS build
+  /// configurations/schemes) for the selected [ProjectConfig.flavors].
+  /// Must run after `flutter create` (native folders must already exist).
+  Future<void> configureFlavors(ProjectConfig config);
 }
 
 /// Implementation of FileSystemDataSource
@@ -2045,6 +2050,156 @@ key.properties
 ''';
     
     gitignoreFile.writeAsStringSync(content);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Native flavors (Android product flavors + iOS build configs/schemes)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @override
+  Future<void> configureFlavors(ProjectConfig config) async {
+    if (config.flavors.isEmpty) return;
+    await _configureAndroidFlavors(config);
+    // iOS flavor configuration is added in a later step.
+  }
+
+  /// Converts a package name into a human friendly app name.
+  /// e.g. `my_awesome_app` -> `My Awesome App`
+  String _humanizeName(String projectName) {
+    return path
+        .basename(projectName)
+        .split(RegExp(r'[_\s]+'))
+        .where((word) => word.isNotEmpty)
+        .map((word) => word[0].toUpperCase() + word.substring(1))
+        .join(' ');
+  }
+
+  Future<void> _configureAndroidFlavors(ProjectConfig config) async {
+    final androidAppDir =
+        Directory(path.join(config.projectName, 'android', 'app'));
+    // Android platform was not generated for this project.
+    if (!androidAppDir.existsSync()) return;
+
+    final appName = _humanizeName(config.projectName);
+    final gradleKts = File(path.join(androidAppDir.path, 'build.gradle.kts'));
+    final gradleGroovy = File(path.join(androidAppDir.path, 'build.gradle'));
+
+    if (gradleKts.existsSync()) {
+      _injectKotlinFlavors(gradleKts, config.flavors, appName);
+    } else if (gradleGroovy.existsSync()) {
+      _injectGroovyFlavors(gradleGroovy, config.flavors, appName);
+    }
+
+    _patchAndroidManifestLabel(config.projectName);
+  }
+
+  /// Injects `flavorDimensions` + `productFlavors` into a Kotlin DSL
+  /// (`build.gradle.kts`) `android { }` block, right before `buildTypes`.
+  void _injectKotlinFlavors(
+    File gradle,
+    List<Flavor> flavors,
+    String appName,
+  ) {
+    var content = gradle.readAsStringSync();
+    if (content.contains('productFlavors')) return; // idempotent
+
+    final block = StringBuffer()
+      ..writeln('    flavorDimensions += "environment"')
+      ..writeln('    productFlavors {');
+    for (final flavor in flavors) {
+      block.writeln('        create("${flavor.flavorName}") {');
+      block.writeln('            dimension = "environment"');
+      if (flavor.bundleIdSuffix.isNotEmpty) {
+        block.writeln(
+          '            applicationIdSuffix = "${flavor.bundleIdSuffix}"',
+        );
+      }
+      block.writeln(
+        '            resValue("string", "app_name", "$appName${flavor.appNameSuffix}")',
+      );
+      block.writeln('        }');
+    }
+    block
+      ..writeln('    }')
+      ..writeln();
+
+    final flavorBlock = block.toString();
+    final anchor = RegExp(r'\n([ \t]*)buildTypes');
+    if (anchor.hasMatch(content)) {
+      content = content.replaceFirstMapped(
+        anchor,
+        (m) => '\n$flavorBlock${m.group(1)}buildTypes',
+      );
+    } else {
+      // Fallback: insert before the final closing brace of the file.
+      final lastBrace = content.lastIndexOf('}');
+      if (lastBrace != -1) {
+        content =
+            '${content.substring(0, lastBrace)}$flavorBlock${content.substring(lastBrace)}';
+      }
+    }
+    gradle.writeAsStringSync(content);
+  }
+
+  /// Injects flavors into a Groovy (`build.gradle`) `android { }` block.
+  void _injectGroovyFlavors(
+    File gradle,
+    List<Flavor> flavors,
+    String appName,
+  ) {
+    var content = gradle.readAsStringSync();
+    if (content.contains('productFlavors')) return; // idempotent
+
+    final block = StringBuffer()
+      ..writeln('    flavorDimensions "environment"')
+      ..writeln('    productFlavors {');
+    for (final flavor in flavors) {
+      block.writeln('        ${flavor.flavorName} {');
+      block.writeln('            dimension "environment"');
+      if (flavor.bundleIdSuffix.isNotEmpty) {
+        block.writeln(
+          '            applicationIdSuffix "${flavor.bundleIdSuffix}"',
+        );
+      }
+      block.writeln(
+        '            resValue "string", "app_name", "$appName${flavor.appNameSuffix}"',
+      );
+      block.writeln('        }');
+    }
+    block
+      ..writeln('    }')
+      ..writeln();
+
+    final flavorBlock = block.toString();
+    final anchor = RegExp(r'\n([ \t]*)buildTypes');
+    if (anchor.hasMatch(content)) {
+      content = content.replaceFirstMapped(
+        anchor,
+        (m) => '\n$flavorBlock${m.group(1)}buildTypes',
+      );
+    } else {
+      final lastBrace = content.lastIndexOf('}');
+      if (lastBrace != -1) {
+        content =
+            '${content.substring(0, lastBrace)}$flavorBlock${content.substring(lastBrace)}';
+      }
+    }
+    gradle.writeAsStringSync(content);
+  }
+
+  /// Points the AndroidManifest label to the per-flavor `app_name` resource.
+  void _patchAndroidManifestLabel(String projectName) {
+    final manifest = File(
+      path.join(projectName, 'android', 'app', 'src', 'main', 'AndroidManifest.xml'),
+    );
+    if (!manifest.existsSync()) return;
+    var content = manifest.readAsStringSync();
+    if (content.contains('android:label="@string/app_name"')) return;
+    content = content.replaceFirst(
+      RegExp(r'android:label="[^"]*"'),
+      'android:label="@string/app_name"',
+    );
+    manifest.writeAsStringSync(content);
   }
 
 

--- a/lib/data/datasources/file_system_datasource.dart
+++ b/lib/data/datasources/file_system_datasource.dart
@@ -2069,6 +2069,11 @@ key.properties
     if (content.contains('productFlavors')) return; // idempotent
 
     final block = StringBuffer()
+      // resValue(...) requires the resValues build feature, which AGP 8+
+      // disables by default.
+      ..writeln('    buildFeatures {')
+      ..writeln('        resValues = true')
+      ..writeln('    }')
       ..writeln('    flavorDimensions += "environment"')
       ..writeln('    productFlavors {');
     for (final flavor in flavors) {
@@ -2116,6 +2121,11 @@ key.properties
     if (content.contains('productFlavors')) return; // idempotent
 
     final block = StringBuffer()
+      // resValue(...) requires the resValues build feature, which AGP 8+
+      // disables by default.
+      ..writeln('    buildFeatures {')
+      ..writeln('        resValues true')
+      ..writeln('    }')
       ..writeln('    flavorDimensions "environment"')
       ..writeln('    productFlavors {');
     for (final flavor in flavors) {

--- a/lib/data/datasources/flutter_command_datasource.dart
+++ b/lib/data/datasources/flutter_command_datasource.dart
@@ -17,11 +17,13 @@ abstract class FlutterCommandDataSource {
 
   Future<void> initializeGit(String projectName);
 
-  Future<void> generateLocalizationFiles(String projectName);
+  /// Returns true if localization generation succeeded.
+  Future<bool> generateLocalizationFiles(String projectName);
 
   Future<void> cleanBuildCache(String projectName);
 
-  Future<void> runBuildRunner(String projectName);
+  /// Returns true if code generation (build_runner) succeeded.
+  Future<bool> runBuildRunner(String projectName);
 
   Future<void> setupCocoaPods(String projectName, List<PlatformType> platforms);
 }
@@ -145,7 +147,7 @@ class FlutterCommandDataSourceImpl implements FlutterCommandDataSource {
   }
 
   @override
-  Future<void> generateLocalizationFiles(String projectName) async {
+  Future<bool> generateLocalizationFiles(String projectName) async {
     try {
       final result = await Process.run(
         'dart',
@@ -153,14 +155,10 @@ class FlutterCommandDataSourceImpl implements FlutterCommandDataSource {
         workingDirectory: projectName,
         runInShell: true,
       );
-
-      if (result.exitCode != 0) {
-        // Silent: runs during spinner animation
-      }
-
       await _fixAppLocalizationsImport(projectName);
+      return result.exitCode == 0;
     } catch (_) {
-      // Silent: runs during spinner animation
+      return false;
     }
   }
 
@@ -206,7 +204,7 @@ class FlutterCommandDataSourceImpl implements FlutterCommandDataSource {
   }
 
   @override
-  Future<void> runBuildRunner(String projectName) async {
+  Future<bool> runBuildRunner(String projectName) async {
     try {
       final result = await Process.run(
         'dart',
@@ -214,12 +212,9 @@ class FlutterCommandDataSourceImpl implements FlutterCommandDataSource {
         workingDirectory: projectName,
         runInShell: true,
       );
-
-      if (result.exitCode != 0) {
-        // Silent: runs during spinner animation
-      }
+      return result.exitCode == 0;
     } catch (_) {
-      // Silent: runs during spinner animation
+      return false;
     }
   }
 

--- a/lib/data/datasources/flutter_command_datasource.dart
+++ b/lib/data/datasources/flutter_command_datasource.dart
@@ -15,6 +15,8 @@ abstract class FlutterCommandDataSource {
 
   Future<bool> isFlutterInstalled();
 
+  Future<void> initializeGit(String projectName);
+
   Future<void> generateLocalizationFiles(String projectName);
 
   Future<void> cleanBuildCache(String projectName);
@@ -117,6 +119,28 @@ class FlutterCommandDataSourceImpl implements FlutterCommandDataSource {
       return result.exitCode == 0;
     } catch (e) {
       return false;
+    }
+  }
+
+  @override
+  Future<void> initializeGit(String projectName) async {
+    // `flutter create` does not initialize a git repository, so do it here
+    // (unless the user passed --no-git). Best-effort: never fail generation.
+    try {
+      final projectDir = Directory(projectName);
+      if (Directory(p.join(projectName, '.git')).existsSync()) return;
+      final init = await Process.run(
+        'git',
+        ['init'],
+        workingDirectory: projectDir.path,
+        runInShell: true,
+      );
+      if (init.exitCode == 0) {
+        await Process.run('git', ['add', '.'],
+            workingDirectory: projectDir.path, runInShell: true);
+      }
+    } catch (_) {
+      // Silent: git may not be installed; not critical to generation.
     }
   }
 

--- a/lib/data/repositories/project_repository_impl.dart
+++ b/lib/data/repositories/project_repository_impl.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import '../../domain/entities/project_config.dart';
 import '../../domain/repositories/project_repository.dart';
 import '../datasources/file_system_datasource.dart';
@@ -16,6 +18,16 @@ class ProjectRepositoryImpl implements ProjectRepository {
 
   @override
   Future<void> createProject(ProjectConfig config) async {
+    // Honor --output: generate inside the requested directory. All downstream
+    // steps use paths relative to the current directory, so switching it here
+    // places the whole project under the chosen output directory.
+    final outputDir = config.outputDirectory;
+    if (outputDir != null && outputDir.trim().isNotEmpty) {
+      final dir = Directory(outputDir);
+      if (!dir.existsSync()) dir.createSync(recursive: true);
+      Directory.current = dir;
+    }
+
     await _flutterCommandDataSource.createFlutterProject(
       projectName: config.projectName,
       organizationName: config.organizationName,
@@ -59,7 +71,11 @@ class ProjectRepositoryImpl implements ProjectRepository {
 
     await _fileSystemDataSource.createBuildYaml(config.projectName);
 
-    await _fileSystemDataSource.createVSCodeLaunchConfig(config.projectName, config.flavors);
+    await _fileSystemDataSource.createVSCodeLaunchConfig(
+      config.projectName,
+      config.flavors,
+      nativeFlavors: config.usesNativeFlavors,
+    );
 
     await _fileSystemDataSource.createGitIgnore(config.projectName);
 
@@ -83,6 +99,11 @@ class ProjectRepositoryImpl implements ProjectRepository {
 
     // Setup CocoaPods for iOS/macOS platforms
     await _flutterCommandDataSource.setupCocoaPods(config.projectName, config.platforms);
+
+    // Initialize git unless the user opted out with --no-git.
+    if (!config.skipGitInit) {
+      await _flutterCommandDataSource.initializeGit(config.projectName);
+    }
   }
 
   @override

--- a/lib/data/repositories/project_repository_impl.dart
+++ b/lib/data/repositories/project_repository_impl.dart
@@ -59,7 +59,7 @@ class ProjectRepositoryImpl implements ProjectRepository {
 
     await _fileSystemDataSource.createBuildYaml(config.projectName);
 
-    await _fileSystemDataSource.createVSCodeLaunchConfig(config.projectName);
+    await _fileSystemDataSource.createVSCodeLaunchConfig(config.projectName, config.flavors);
 
     await _fileSystemDataSource.createGitIgnore(config.projectName);
 

--- a/lib/data/repositories/project_repository_impl.dart
+++ b/lib/data/repositories/project_repository_impl.dart
@@ -25,6 +25,10 @@ class ProjectRepositoryImpl implements ProjectRepository {
       customDesktopPlatforms: config.customDesktopPlatforms,
     );
 
+    // Configure native flavors (Android product flavors + iOS build
+    // configs/schemes) right after the native folders are generated.
+    await _fileSystemDataSource.configureFlavors(config);
+
     await _fileSystemDataSource.addDependencies(
       config.projectName, 
       StateManagementType.bloc, 

--- a/lib/data/repositories/project_repository_impl.dart
+++ b/lib/data/repositories/project_repository_impl.dart
@@ -17,7 +17,8 @@ class ProjectRepositoryImpl implements ProjectRepository {
         _flutterCommandDataSource = flutterCommandDataSource;
 
   @override
-  Future<void> createProject(ProjectConfig config) async {
+  Future<List<String>> createProject(ProjectConfig config) async {
+    final warnings = <String>[];
     // Honor --output: generate inside the requested directory. All downstream
     // steps use paths relative to the current directory, so switching it here
     // places the whole project under the chosen output directory.
@@ -92,10 +93,22 @@ class ProjectRepositoryImpl implements ProjectRepository {
     await _flutterCommandDataSource.cleanBuildCache(config.projectName);
 
     // Generar archivos de localización (requiere intl_utils instalado)
-    await _flutterCommandDataSource.generateLocalizationFiles(config.projectName);
+    final l10nOk =
+        await _flutterCommandDataSource.generateLocalizationFiles(config.projectName);
+    if (!l10nOk) {
+      warnings.add(
+        'Localization generation failed. Run: dart run intl_utils:generate',
+      );
+    }
 
     // Generar archivos de Freezed y Drift (requiere build_runner instalado)
-    await _flutterCommandDataSource.runBuildRunner(config.projectName);
+    final buildRunnerOk =
+        await _flutterCommandDataSource.runBuildRunner(config.projectName);
+    if (!buildRunnerOk) {
+      warnings.add(
+        'Code generation failed. Run: dart run build_runner build -d',
+      );
+    }
 
     // Setup CocoaPods for iOS/macOS platforms
     await _flutterCommandDataSource.setupCocoaPods(config.projectName, config.platforms);
@@ -104,6 +117,8 @@ class ProjectRepositoryImpl implements ProjectRepository {
     if (!config.skipGitInit) {
       await _flutterCommandDataSource.initializeGit(config.projectName);
     }
+
+    return warnings;
   }
 
   @override

--- a/lib/domain/entities/project_config.dart
+++ b/lib/domain/entities/project_config.dart
@@ -305,6 +305,26 @@ enum Flavor {
   /// Full bundleId for this flavor given the [baseId] the user entered
   /// (the base id is the production id).
   String bundleId(String baseId) => '$baseId$bundleIdSuffix';
+
+  /// Parses a user-supplied flavor token (case-insensitive, lenient aliases).
+  /// Returns null if it doesn't match any flavor.
+  static Flavor? tryParse(String value) {
+    switch (value.trim().toLowerCase()) {
+      case 'dev':
+      case 'develop':
+      case 'development':
+        return Flavor.dev;
+      case 'stg':
+      case 'stage':
+      case 'staging':
+        return Flavor.staging;
+      case 'prod':
+      case 'production':
+        return Flavor.production;
+      default:
+        return null;
+    }
+  }
 }
 
 /// Enum representing different state management types

--- a/lib/domain/entities/project_config.dart
+++ b/lib/domain/entities/project_config.dart
@@ -206,9 +206,15 @@ class CustomDesktopPlatforms {
 
 /// Enum representing the native build flavors of the generated project.
 ///
-/// Each flavor maps to an Android product flavor + iOS build configuration,
-/// a dedicated entry point (`main_<shortName>.dart`) and a distinct
-/// applicationId/bundleId so the flavors can be installed side by side.
+/// Each flavor maps to an Android product flavor + iOS build configuration and
+/// scheme, a dedicated Dart entry point (`main_<entryPoint>.dart`) and a
+/// distinct bundleId so the flavors can be installed side by side.
+///
+/// The bundleId the user enters is treated as **production** (the clean base);
+/// dev/staging derive their id by appending a suffix. e.g. base `com.test.app`:
+///   production -> com.test.app        (no suffix)
+///   dev        -> com.test.app.dev
+///   staging    -> com.test.app.stage
 enum Flavor {
   dev,
   staging,
@@ -226,8 +232,21 @@ enum Flavor {
     }
   }
 
-  /// Identifier used for entry points, schemes and gradle flavor names.
-  String get shortName {
+  /// Name used for `flutter --flavor`, the Android product flavor and the iOS
+  /// scheme / build configuration (matches the JornaDay reference: dev/prod).
+  String get flavorName {
+    switch (this) {
+      case Flavor.dev:
+        return 'dev';
+      case Flavor.staging:
+        return 'staging';
+      case Flavor.production:
+        return 'prod';
+    }
+  }
+
+  /// Dart entry point file name: `lib/main_<entryPoint>.dart`.
+  String get entryPoint {
     switch (this) {
       case Flavor.dev:
         return 'dev';
@@ -238,14 +257,26 @@ enum Flavor {
     }
   }
 
-  /// Suffix appended to the base applicationId/bundleId.
-  /// Production keeps the base id (no suffix) so store builds stay clean.
-  String get applicationIdSuffix {
+  /// `AppEnvironment.<environment>` used inside the entry point.
+  String get environment {
+    switch (this) {
+      case Flavor.dev:
+        return 'dev';
+      case Flavor.staging:
+        return 'staging';
+      case Flavor.production:
+        return 'production';
+    }
+  }
+
+  /// Suffix appended to the base bundleId/applicationId.
+  /// Production keeps the base id the user typed (no suffix).
+  String get bundleIdSuffix {
     switch (this) {
       case Flavor.dev:
         return '.dev';
       case Flavor.staging:
-        return '.stg';
+        return '.stage';
       case Flavor.production:
         return '';
     }
@@ -257,23 +288,15 @@ enum Flavor {
       case Flavor.dev:
         return ' Dev';
       case Flavor.staging:
-        return ' Stg';
+        return ' Stage';
       case Flavor.production:
         return '';
     }
   }
 
-  /// Suffix appended to the versionName on Android (empty for production).
-  String get versionNameSuffix {
-    switch (this) {
-      case Flavor.dev:
-        return '-dev';
-      case Flavor.staging:
-        return '-stg';
-      case Flavor.production:
-        return '';
-    }
-  }
+  /// Full bundleId for this flavor given the [baseId] the user entered
+  /// (the base id is the production id).
+  String bundleId(String baseId) => '$baseId$bundleIdSuffix';
 }
 
 /// Enum representing different state management types

--- a/lib/domain/entities/project_config.dart
+++ b/lib/domain/entities/project_config.dart
@@ -14,6 +14,10 @@ class ProjectConfig {
   final String? outputDirectory;
   final bool skipGitInit;
 
+  /// Native flavors to generate (dev, staging, production).
+  /// Each flavor gets its own applicationId/bundleId, app name and entry point.
+  final List<Flavor> flavors;
+
   const ProjectConfig({
     required this.projectName,
     required this.organizationName,
@@ -28,6 +32,7 @@ class ProjectConfig {
     this.customDesktopPlatforms,
     this.outputDirectory,
     this.skipGitInit = false,
+    this.flavors = const [Flavor.dev, Flavor.staging, Flavor.production],
   });
 
   /// Validates the project configuration
@@ -48,7 +53,7 @@ class ProjectConfig {
 
   @override
   String toString() {
-    return 'ProjectConfig(projectName: $projectName, organizationName: $organizationName, stateManagement: $stateManagement, architecture: $architecture, includeGoRouter: $includeGoRouter, includeLinterRules: $includeLinterRules, includeFreezed: $includeFreezed, platforms: $platforms, mobilePlatform: $mobilePlatform, desktopPlatform: $desktopPlatform, customDesktopPlatforms: $customDesktopPlatforms, outputDirectory: $outputDirectory, skipGitInit: $skipGitInit)';
+    return 'ProjectConfig(projectName: $projectName, organizationName: $organizationName, stateManagement: $stateManagement, architecture: $architecture, includeGoRouter: $includeGoRouter, includeLinterRules: $includeLinterRules, includeFreezed: $includeFreezed, platforms: $platforms, mobilePlatform: $mobilePlatform, desktopPlatform: $desktopPlatform, customDesktopPlatforms: $customDesktopPlatforms, outputDirectory: $outputDirectory, skipGitInit: $skipGitInit, flavors: $flavors)';
   }
 
   @override
@@ -67,7 +72,8 @@ class ProjectConfig {
         other.desktopPlatform == desktopPlatform &&
         other.customDesktopPlatforms == customDesktopPlatforms &&
         other.outputDirectory == outputDirectory &&
-        other.skipGitInit == skipGitInit;
+        other.skipGitInit == skipGitInit &&
+        other.flavors == flavors;
   }
 
   @override
@@ -84,7 +90,8 @@ class ProjectConfig {
         desktopPlatform.hashCode ^
         customDesktopPlatforms.hashCode ^
         outputDirectory.hashCode ^
-        skipGitInit.hashCode;
+        skipGitInit.hashCode ^
+        flavors.hashCode;
   }
 }
 
@@ -194,6 +201,78 @@ class CustomDesktopPlatforms {
     if (macos) platforms.add('macos');
     if (linux) platforms.add('linux');
     return platforms;
+  }
+}
+
+/// Enum representing the native build flavors of the generated project.
+///
+/// Each flavor maps to an Android product flavor + iOS build configuration,
+/// a dedicated entry point (`main_<shortName>.dart`) and a distinct
+/// applicationId/bundleId so the flavors can be installed side by side.
+enum Flavor {
+  dev,
+  staging,
+  production;
+
+  /// Human readable name shown in prompts/summaries.
+  String get displayName {
+    switch (this) {
+      case Flavor.dev:
+        return 'Development';
+      case Flavor.staging:
+        return 'Staging';
+      case Flavor.production:
+        return 'Production';
+    }
+  }
+
+  /// Identifier used for entry points, schemes and gradle flavor names.
+  String get shortName {
+    switch (this) {
+      case Flavor.dev:
+        return 'dev';
+      case Flavor.staging:
+        return 'staging';
+      case Flavor.production:
+        return 'production';
+    }
+  }
+
+  /// Suffix appended to the base applicationId/bundleId.
+  /// Production keeps the base id (no suffix) so store builds stay clean.
+  String get applicationIdSuffix {
+    switch (this) {
+      case Flavor.dev:
+        return '.dev';
+      case Flavor.staging:
+        return '.stg';
+      case Flavor.production:
+        return '';
+    }
+  }
+
+  /// Suffix appended to the visible app name (empty for production).
+  String get appNameSuffix {
+    switch (this) {
+      case Flavor.dev:
+        return ' Dev';
+      case Flavor.staging:
+        return ' Stg';
+      case Flavor.production:
+        return '';
+    }
+  }
+
+  /// Suffix appended to the versionName on Android (empty for production).
+  String get versionNameSuffix {
+    switch (this) {
+      case Flavor.dev:
+        return '-dev';
+      case Flavor.staging:
+        return '-stg';
+      case Flavor.production:
+        return '';
+    }
   }
 }
 

--- a/lib/domain/entities/project_config.dart
+++ b/lib/domain/entities/project_config.dart
@@ -37,18 +37,26 @@ class ProjectConfig {
 
   /// Validates the project configuration
   bool get isValid {
-    return isValidProjectName(projectName) && 
+    return isValidProjectName(projectName) &&
            isValidOrganizationName(organizationName);
   }
+
+  /// Whether native flavors (Android product flavors / iOS schemes) apply.
+  /// Flavors are only wired natively for mobile; web and (Windows/Linux)
+  /// desktop do not support `flutter run --flavor`.
+  bool get usesNativeFlavors => platforms.contains(PlatformType.mobile);
 
   /// Validates project name format
   static bool isValidProjectName(String name) {
     return RegExp(r'^[a-z][a-z0-9_]*$').hasMatch(name);
   }
 
-  /// Validates organization name format (allows underscores for project name compatibility)
+  /// Validates organization name format: dot-separated segments, each starting
+  /// with a letter (e.g. `com.example`). Rejects consecutive/trailing dots,
+  /// which would produce an invalid applicationId/bundleId.
   static bool isValidOrganizationName(String name) {
-    return RegExp(r'^[a-z][a-z0-9._]*[a-z0-9]$').hasMatch(name);
+    if (name.length < 2) return false;
+    return RegExp(r'^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$').hasMatch(name);
   }
 
   @override

--- a/lib/domain/repositories/project_repository.dart
+++ b/lib/domain/repositories/project_repository.dart
@@ -2,8 +2,10 @@ import '../entities/project_config.dart';
 
 /// Repository interface for project creation operations
 abstract class ProjectRepository {
-  /// Creates a Flutter project with the given configuration
-  Future<void> createProject(ProjectConfig config);
+  /// Creates a Flutter project with the given configuration.
+  /// Returns a list of non-fatal warnings (e.g. a post-generation step such
+  /// as build_runner or intl_utils failed); empty means fully successful.
+  Future<List<String>> createProject(ProjectConfig config);
   
   /// Adds state management dependencies and templates to the project
   Future<void> addStateManagement(String projectName, StateManagementType stateManagement);

--- a/lib/presentation/controllers/cli_controller.dart
+++ b/lib/presentation/controllers/cli_controller.dart
@@ -9,18 +9,22 @@ class CliController {
   CliController(this._projectRepository, {Logger? logger})
       : _logger = logger ?? Logger();
 
-  Future<void> runInteractiveMode() async {
+  Future<void> runInteractiveMode({
+    String? organization,
+    String? outputDir,
+    bool noGit = false,
+  }) async {
     _printWelcomeMessage();
 
     final projectName = _getProjectName();
-    final organization = _getOrganization(projectName);
+    final org = _getOrganization(projectName, organization);
     final platforms = _getPlatforms();
     final flavors = _getFlavors();
     final includeLinterRules = _getLinterRulesChoice();
 
     final config = ProjectConfig(
       projectName: projectName,
-      organizationName: organization,
+      organizationName: org,
       platforms: platforms,
       stateManagement: StateManagementType.bloc,
       architecture: ArchitectureType.cleanArchitecture,
@@ -32,6 +36,8 @@ class CliController {
           ? DesktopPlatform.custom
           : DesktopPlatform.all,
       customDesktopPlatforms: _selectedDesktopPlatforms,
+      outputDirectory: outputDir,
+      skipGitInit: noGit,
       flavors: flavors,
     );
 
@@ -151,8 +157,13 @@ class CliController {
     }
   }
 
-  String _getOrganization(String projectName) {
-    final defaultOrg = 'com.$projectName';
+  String _getOrganization(String projectName, [String? provided]) {
+    // If --org was passed and is valid, use it as the default (the user can
+    // still confirm or change it); otherwise fall back to com.<projectName>.
+    final defaultOrg =
+        (provided != null && ProjectConfig.isValidOrganizationName(provided))
+            ? provided
+            : 'com.$projectName';
 
     while (true) {
       final org = _logger.prompt(

--- a/lib/presentation/controllers/cli_controller.dart
+++ b/lib/presentation/controllers/cli_controller.dart
@@ -392,19 +392,22 @@ class CliController {
       progress.complete('Project created successfully');
 
       final firstFlavor = config.flavors.first;
+      final native = config.usesNativeFlavors;
+      String runCmd(Flavor f) => native
+          ? 'flutter run --flavor ${f.flavorName} -t lib/main_${f.entryPoint}.dart'
+          : 'flutter run -t lib/main_${f.entryPoint}.dart';
       _logger
         ..info('')
         ..info(styleBold.wrap(green.wrap('  Done!')))
         ..info('')
         ..info(styleDim.wrap('  Next steps:'))
         ..info('    cd ${config.projectName}')
-        ..info('    flutter run --flavor ${firstFlavor.flavorName} -t lib/main_${firstFlavor.entryPoint}.dart')
+        ..info('    ${runCmd(firstFlavor)}')
         ..info('')
         ..info(styleDim.wrap('  Run flavors:'));
       for (final flavor in config.flavors) {
         _logger.info(
-          '    flutter run --flavor ${flavor.flavorName} -t lib/main_${flavor.entryPoint}.dart'
-          '  ${styleDim.wrap('# ${flavor.displayName}')}',
+          '    ${runCmd(flavor)}  ${styleDim.wrap('# ${flavor.displayName}')}',
         );
       }
       _logger.info('');

--- a/lib/presentation/controllers/cli_controller.dart
+++ b/lib/presentation/controllers/cli_controller.dart
@@ -13,13 +13,15 @@ class CliController {
     String? organization,
     String? outputDir,
     bool noGit = false,
+    List<Flavor>? flavors,
   }) async {
     _printWelcomeMessage();
 
     final projectName = _getProjectName();
     final org = _getOrganization(projectName, organization);
     final platforms = _getPlatforms();
-    final flavors = _getFlavors();
+    // If flavors were passed via --flavors, honor them and skip the prompt.
+    final selectedFlavors = flavors ?? _getFlavors();
     final includeLinterRules = _getLinterRulesChoice();
 
     final config = ProjectConfig(
@@ -38,7 +40,7 @@ class CliController {
       customDesktopPlatforms: _selectedDesktopPlatforms,
       outputDirectory: outputDir,
       skipGitInit: noGit,
-      flavors: flavors,
+      flavors: selectedFlavors,
     );
 
     _printConfigurationSummary(config);
@@ -56,6 +58,7 @@ class CliController {
     String? outputDir,
     bool noGit = false,
     bool quickMode = false,
+    List<Flavor>? flavors,
   }) async {
     _printWelcomeMessage();
 
@@ -109,6 +112,7 @@ class CliController {
       customDesktopPlatforms: null,
       outputDirectory: outputDir,
       skipGitInit: noGit,
+      flavors: flavors ?? const [Flavor.dev, Flavor.staging, Flavor.production],
     );
 
     _printConfigurationSummary(config);

--- a/lib/presentation/controllers/cli_controller.dart
+++ b/lib/presentation/controllers/cli_controller.dart
@@ -1,27 +1,17 @@
-import 'package:interact/interact.dart';
-import '../../core/utils/ansi_colors.dart';
+import 'package:mason_logger/mason_logger.dart';
 import '../../domain/entities/project_config.dart';
 import '../../domain/repositories/project_repository.dart';
 
 class CliController {
   final ProjectRepository _projectRepository;
+  final Logger _logger;
 
-  CliController(this._projectRepository);
-
-  // Short aliases for AnsiColors
-  static const String _reset = AnsiColors.reset;
-  static const String _bold = AnsiColors.bold;
-  static const String _dim = AnsiColors.dim;
-  static const String _green = AnsiColors.green;
-  static const String _yellow = AnsiColors.yellow;
-  static const String _cyan = AnsiColors.cyan;
-  static const String _red = AnsiColors.red;
-  static const String _brightGreen = AnsiColors.brightGreen;
-  static const String _brightMagenta = AnsiColors.brightMagenta;
+  CliController(this._projectRepository, {Logger? logger})
+      : _logger = logger ?? Logger();
 
   Future<void> runInteractiveMode() async {
     _printWelcomeMessage();
-    
+
     final projectName = _getProjectName();
     final organization = _getOrganization(projectName);
     final platforms = _getPlatforms();
@@ -37,12 +27,14 @@ class CliController {
       includeLinterRules: includeLinterRules,
       includeFreezed: true,
       mobilePlatform: _selectedMobilePlatform,
-      desktopPlatform: _selectedDesktopPlatforms != null ? DesktopPlatform.custom : DesktopPlatform.all,
+      desktopPlatform: _selectedDesktopPlatforms != null
+          ? DesktopPlatform.custom
+          : DesktopPlatform.all,
       customDesktopPlatforms: _selectedDesktopPlatforms,
     );
 
     _printConfigurationSummary(config);
-    
+
     if (_confirmConfiguration()) {
       await _createProject(config);
     } else {
@@ -58,13 +50,13 @@ class CliController {
     bool quickMode = false,
   }) async {
     _printWelcomeMessage();
-    
+
     // Get or validate project name
     String finalProjectName;
     if (projectName != null && projectName.isNotEmpty) {
-      if (!RegExp(r'^[a-z][a-z0-9_]*$').hasMatch(projectName)) {
-        print('$_red  Invalid project name: $projectName$_reset');
-        print('$_dim  Must be lowercase with underscores only.$_reset');
+      if (!ProjectConfig.isValidProjectName(projectName)) {
+        _logger.err('Invalid project name: $projectName');
+        _logger.detail('Must be lowercase with underscores only.');
         return;
       }
       finalProjectName = projectName;
@@ -72,29 +64,29 @@ class CliController {
       // In quick mode without name, ask for it
       finalProjectName = _getProjectName();
     } else {
-      print('$_red  Project name is required.$_reset');
-      print('$_dim  Use: vgv -n <name>$_reset');
+      _logger.err('Project name is required.');
+      _logger.detail('Use: vgv -n <name>');
       return;
     }
-    
+
     // Get or use default organization based on project name
     String finalOrganization;
     if (organization != null && organization.isNotEmpty) {
-      if (!RegExp(r'^[a-z][a-z0-9._]*[a-z0-9]$').hasMatch(organization)) {
-        print('$_red  Invalid organization: $organization$_reset');
-        print('$_dim  Must be lowercase with dots (e.g., com.example)$_reset');
+      if (!ProjectConfig.isValidOrganizationName(organization)) {
+        _logger.err('Invalid organization: $organization');
+        _logger.detail('Must be lowercase with dots (e.g., com.example)');
         return;
       }
       finalOrganization = organization;
     } else {
       finalOrganization = 'com.$finalProjectName';
     }
-    
+
     // Default platforms for quick/flag mode
     final platforms = [PlatformType.mobile, PlatformType.web];
     _selectedMobilePlatform = MobilePlatform.both;
     _selectedDesktopPlatforms = null;
-    
+
     final config = ProjectConfig(
       projectName: finalProjectName,
       organizationName: finalOrganization,
@@ -110,9 +102,9 @@ class CliController {
       outputDirectory: outputDir,
       skipGitInit: noGit,
     );
-    
+
     _printConfigurationSummary(config);
-    
+
     if (quickMode) {
       // In quick mode, proceed without confirmation
       await _createProject(config);
@@ -124,59 +116,58 @@ class CliController {
   }
 
   void _printWelcomeMessage() {
-    print('');
-    print('$_brightMagenta$_bold  ██╗   ██╗ ██████╗ ██╗   ██╗$_reset');
-    print('$_brightMagenta$_bold  ██║   ██║██╔════╝ ██║   ██║$_reset');
-    print('$_brightMagenta$_bold  ██║   ██║██║  ███╗██║   ██║$_reset');
-    print('$_brightMagenta$_bold  ╚██╗ ██╔╝██║   ██║╚██╗ ██╔╝$_reset');
-    print('$_brightMagenta$_bold   ╚████╔╝ ╚██████╔╝ ╚████╔╝ $_reset');
-    print('$_brightMagenta$_bold    ╚═══╝   ╚═════╝   ╚═══╝  $_reset');
-    print('');
-    print('$_dim  The Ultimate Flutter Project Generator$_reset');
-    print('');
+    String banner(String line) => styleBold.wrap(lightMagenta.wrap(line)!)!;
+    _logger
+      ..info('')
+      ..info(banner('  ██╗   ██╗ ██████╗ ██╗   ██╗'))
+      ..info(banner('  ██║   ██║██╔════╝ ██║   ██║'))
+      ..info(banner('  ██║   ██║██║  ███╗██║   ██║'))
+      ..info(banner('  ╚██╗ ██╔╝██║   ██║╚██╗ ██╔╝'))
+      ..info(banner('   ╚████╔╝ ╚██████╔╝ ╚████╔╝ '))
+      ..info(banner('    ╚═══╝   ╚═════╝   ╚═══╝  '))
+      ..info('')
+      ..info(styleDim.wrap('  The Ultimate Flutter Project Generator'))
+      ..info('');
   }
 
   String _getProjectName() {
     while (true) {
-      final name = Input(
-        prompt: 'Project name',
-        defaultValue: '',
-      ).interact();
-      
+      final name = _logger.prompt('${lightCyan.wrap('?')} Project name');
+
       if (name.isEmpty) {
-        print('$_red  Project name cannot be empty.$_reset');
+        _logger.err('Project name cannot be empty.');
         continue;
       }
-      
-      if (!RegExp(r'^[a-z][a-z0-9_]*$').hasMatch(name)) {
-        print('$_red  Project name must be lowercase with underscores only.$_reset');
-        print('$_dim  Example: my_awesome_app, flutter_app, todo_list$_reset');
+
+      if (!ProjectConfig.isValidProjectName(name)) {
+        _logger.err('Project name must be lowercase with underscores only.');
+        _logger.detail('Example: my_awesome_app, flutter_app, todo_list');
         continue;
       }
-      
+
       return name;
     }
   }
 
   String _getOrganization(String projectName) {
     final defaultOrg = 'com.$projectName';
-    
+
     while (true) {
-      final org = Input(
-        prompt: 'Organization',
+      final org = _logger.prompt(
+        '${lightCyan.wrap('?')} Organization',
         defaultValue: defaultOrg,
-      ).interact();
-      
+      );
+
       if (org.isEmpty) {
         return defaultOrg;
       }
-      
-      if (!RegExp(r'^[a-z][a-z0-9._]*[a-z0-9]$').hasMatch(org)) {
-        print('$_red  Organization must be lowercase with dots, min 2 chars.$_reset');
-        print('$_dim  Example: com.example, dev.mycompany$_reset');
+
+      if (!ProjectConfig.isValidOrganizationName(org)) {
+        _logger.err('Organization must be lowercase with dots, min 2 chars.');
+        _logger.detail('Example: com.example, dev.mycompany');
         continue;
       }
-      
+
       return org;
     }
   }
@@ -186,9 +177,7 @@ class CliController {
   CustomDesktopPlatforms? _selectedDesktopPlatforms;
 
   List<PlatformType> _getPlatforms() {
-    print('');
-    
-    final platformOptions = [
+    const platformOptions = [
       'Mobile Only (Android & iOS)',
       'Web Only',
       'Desktop Only (Windows, macOS, Linux)',
@@ -199,11 +188,12 @@ class CliController {
       'Custom Selection',
     ];
 
-    final selection = Select(
-      prompt: 'Select platforms',
-      options: platformOptions,
-      initialIndex: 0,
-    ).interact();
+    final selected = _logger.chooseOne(
+      '${lightCyan.wrap('?')} Select platforms',
+      choices: platformOptions,
+      defaultValue: platformOptions.first,
+    );
+    final selection = platformOptions.indexOf(selected);
 
     // Reset custom selections
     _selectedMobilePlatform = MobilePlatform.both;
@@ -232,29 +222,27 @@ class CliController {
   }
 
   List<PlatformType> _getCustomPlatformSelection() {
-    print('');
-    
-    final platformOptions = [
-      'Android',
-      'iOS',
-      'Web',
-      'Windows',
-      'macOS',
-      'Linux',
-    ];
+    const android = 'Android';
+    const ios = 'iOS';
+    const web = 'Web';
+    const windows = 'Windows';
+    const macos = 'macOS';
+    const linux = 'Linux';
+    const platformOptions = [android, ios, web, windows, macos, linux];
 
-    final selections = MultiSelect(
-      prompt: 'Select platforms (space to toggle, enter to confirm)',
-      options: platformOptions,
-      defaults: [true, true, false, false, false, false],
-    ).interact();
+    final selections = _logger.chooseAny(
+      '${lightCyan.wrap('?')} Select platforms '
+      '${styleDim.wrap('(space to toggle, enter to confirm)')}',
+      choices: platformOptions,
+      defaultValues: const [android, ios],
+    );
 
     final platforms = <PlatformType>[];
-    
+
     // Track specific mobile platforms
-    final hasAndroid = selections.contains(0);
-    final hasIOS = selections.contains(1);
-    
+    final hasAndroid = selections.contains(android);
+    final hasIOS = selections.contains(ios);
+
     if (hasAndroid || hasIOS) {
       platforms.add(PlatformType.mobile);
       if (hasAndroid && hasIOS) {
@@ -265,17 +253,17 @@ class CliController {
         _selectedMobilePlatform = MobilePlatform.ios;
       }
     }
-    
+
     // Track web
-    if (selections.contains(2)) {
+    if (selections.contains(web)) {
       platforms.add(PlatformType.web);
     }
-    
+
     // Track specific desktop platforms
-    final hasWindows = selections.contains(3);
-    final hasMacOS = selections.contains(4);
-    final hasLinux = selections.contains(5);
-    
+    final hasWindows = selections.contains(windows);
+    final hasMacOS = selections.contains(macos);
+    final hasLinux = selections.contains(linux);
+
     if (hasWindows || hasMacOS || hasLinux) {
       platforms.add(PlatformType.desktop);
       _selectedDesktopPlatforms = CustomDesktopPlatforms(
@@ -284,46 +272,49 @@ class CliController {
         linux: hasLinux,
       );
     }
-    
+
     if (platforms.isEmpty) {
-      print('$_yellow  No platforms selected. Defaulting to Mobile.$_reset');
+      _logger.warn('No platforms selected. Defaulting to Mobile.');
       platforms.add(PlatformType.mobile);
       _selectedMobilePlatform = MobilePlatform.both;
     }
-    
+
     return platforms;
   }
 
   bool _getLinterRulesChoice() {
-    print('');
-    return Confirm(
-      prompt: 'Include custom linter rules?',
+    return _logger.confirm(
+      '${lightCyan.wrap('?')} Include custom linter rules?',
       defaultValue: false,
-    ).interact();
+    );
   }
 
   void _printConfigurationSummary(ProjectConfig config) {
-    print('');
-    print('$_cyan$_bold  Configuration Summary$_reset');
-    print('$_dim  ─────────────────────────────────────────$_reset');
-    print('');
-    print('  $_dim Project:$_reset       $_brightGreen${config.projectName}$_reset');
-    print('  $_dim Organization:$_reset  $_brightGreen${config.organizationName}$_reset');
-    print('  $_dim Platforms:$_reset     $_brightGreen${_formatPlatforms(config.platforms)}$_reset');
-    print('  $_dim State:$_reset         ${_brightGreen}BLoC$_reset');
-    print('  $_dim Navigation:$_reset    ${_brightGreen}Go Router$_reset');
-    print('  $_dim Architecture:$_reset  ${_brightGreen}Clean Architecture$_reset');
-    print('  $_dim Code Gen:$_reset      ${_brightGreen}Freezed$_reset');
-    print('  $_dim Environments:$_reset  ${_brightGreen}Dev, Staging, Production$_reset');
+    String label(String text) => styleDim.wrap(text)!;
+    String value(String text) => lightGreen.wrap(text)!;
+
+    _logger
+      ..info('')
+      ..info(styleBold.wrap(cyan.wrap('  Configuration Summary')))
+      ..info(styleDim.wrap('  ─────────────────────────────────────────'))
+      ..info('')
+      ..info('  ${label('Project:')}       ${value(config.projectName)}')
+      ..info('  ${label('Organization:')}  ${value(config.organizationName)}')
+      ..info('  ${label('Platforms:')}     ${value(_formatPlatforms(config.platforms))}')
+      ..info('  ${label('State:')}         ${value('BLoC')}')
+      ..info('  ${label('Navigation:')}    ${value('Go Router')}')
+      ..info('  ${label('Architecture:')}  ${value('Clean Architecture')}')
+      ..info('  ${label('Code Gen:')}      ${value('Freezed')}')
+      ..info('  ${label('Environments:')}  ${value('Dev, Staging, Production')}');
     if (config.includeLinterRules) {
-      print('  $_dim Linter:$_reset        ${_brightGreen}Custom Rules$_reset');
+      _logger.info('  ${label('Linter:')}        ${value('Custom Rules')}');
     }
-    print('');
+    _logger.info('');
   }
 
   String _formatPlatforms(List<PlatformType> platforms) {
     final names = <String>[];
-    
+
     for (final p in platforms) {
       switch (p) {
         case PlatformType.mobile:
@@ -348,63 +339,58 @@ class CliController {
           }
       }
     }
-    
+
     return names.join(', ');
   }
 
   bool _confirmConfiguration() {
-    return Confirm(
-      prompt: 'Create project with this configuration?',
+    return _logger.confirm(
+      '${lightCyan.wrap('?')} Create project with this configuration?',
       defaultValue: true,
-    ).interact();
+    );
   }
 
   Future<void> _createProject(ProjectConfig config) async {
-    print('');
-    
-    final spinner = Spinner(
-      icon: '$_brightGreen[+]$_reset',
-      leftPrompt: (done) => '',
-      rightPrompt: (done) => done 
-          ? '$_brightGreen Project created successfully$_reset'
-          : '$_cyan Creating Flutter project...$_reset',
-    ).interact();
-    
+    _logger.info('');
+
+    final progress = _logger.progress('Creating Flutter project...');
+
     try {
       await _projectRepository.createProject(config);
-      spinner.done();
-      
-      print('');
-      print('$_green$_bold  Done!$_reset');
-      print('');
-      print('$_dim  Next steps:$_reset');
-      print('    cd ${config.projectName}');
-      print('    flutter run -t lib/main_dev.dart');
-      print('');
-      print('$_dim  Run environments:$_reset');
-      print('    flutter run -t lib/main_dev.dart        $_dim# Development$_reset');
-      print('    flutter run -t lib/main_staging.dart    $_dim# Staging$_reset');
-      print('    flutter run -t lib/main_production.dart $_dim# Production$_reset');
-      print('');
-      
+      progress.complete('Project created successfully');
+
+      _logger
+        ..info('')
+        ..info(styleBold.wrap(green.wrap('  Done!')))
+        ..info('')
+        ..info(styleDim.wrap('  Next steps:'))
+        ..info('    cd ${config.projectName}')
+        ..info('    flutter run -t lib/main_dev.dart')
+        ..info('')
+        ..info(styleDim.wrap('  Run environments:'))
+        ..info('    flutter run -t lib/main_dev.dart        ${styleDim.wrap('# Development')}')
+        ..info('    flutter run -t lib/main_staging.dart    ${styleDim.wrap('# Staging')}')
+        ..info('    flutter run -t lib/main_production.dart ${styleDim.wrap('# Production')}')
+        ..info('');
     } catch (e) {
-      spinner.done();
-      print('');
-      print('$_red$_bold  Error creating project:$_reset');
-      print('$_red  $e$_reset');
-      print('');
-      print('$_dim  Troubleshooting:$_reset');
-      print('    - Check your Flutter installation');
-      print('    - Ensure you have write permissions');
-      print('    - Try running: flutter doctor');
-      print('');
+      progress.fail('Failed to create project');
+      _logger
+        ..err('  Error creating project:')
+        ..err('  $e')
+        ..info('')
+        ..info(styleDim.wrap('  Troubleshooting:'))
+        ..info('    - Check your Flutter installation')
+        ..info('    - Ensure you have write permissions')
+        ..info('    - Try running: flutter doctor')
+        ..info('');
     }
   }
 
   void _printCancelledMessage() {
-    print('');
-    print('$_yellow  Project creation cancelled.$_reset');
-    print('$_dim  Run vgv again when ready.$_reset');
-    print('');
+    _logger
+      ..info('')
+      ..warn('Project creation cancelled.')
+      ..info(styleDim.wrap('  Run vgv again when ready.'))
+      ..info('');
   }
 }

--- a/lib/presentation/controllers/cli_controller.dart
+++ b/lib/presentation/controllers/cli_controller.dart
@@ -331,6 +331,16 @@ class CliController {
     if (config.includeLinterRules) {
       _logger.info('  ${label('Linter:')}        ${value('Custom Rules')}');
     }
+
+    // Bundle ID preview: the entered id is production; others derive a suffix.
+    final baseId = '${config.organizationName}.${config.projectName}';
+    _logger
+      ..info('')
+      ..info('  ${label('Bundle IDs')}');
+    for (final flavor in config.flavors) {
+      final name = flavor.displayName.padRight(12);
+      _logger.info('    ${styleDim.wrap(name)} ${value(flavor.bundleId(baseId))}');
+    }
     _logger.info('');
   }
 

--- a/lib/presentation/controllers/cli_controller.dart
+++ b/lib/presentation/controllers/cli_controller.dart
@@ -391,19 +391,23 @@ class CliController {
       await _projectRepository.createProject(config);
       progress.complete('Project created successfully');
 
+      final firstFlavor = config.flavors.first;
       _logger
         ..info('')
         ..info(styleBold.wrap(green.wrap('  Done!')))
         ..info('')
         ..info(styleDim.wrap('  Next steps:'))
         ..info('    cd ${config.projectName}')
-        ..info('    flutter run -t lib/main_dev.dart')
+        ..info('    flutter run --flavor ${firstFlavor.flavorName} -t lib/main_${firstFlavor.entryPoint}.dart')
         ..info('')
-        ..info(styleDim.wrap('  Run environments:'))
-        ..info('    flutter run -t lib/main_dev.dart        ${styleDim.wrap('# Development')}')
-        ..info('    flutter run -t lib/main_staging.dart    ${styleDim.wrap('# Staging')}')
-        ..info('    flutter run -t lib/main_production.dart ${styleDim.wrap('# Production')}')
-        ..info('');
+        ..info(styleDim.wrap('  Run flavors:'));
+      for (final flavor in config.flavors) {
+        _logger.info(
+          '    flutter run --flavor ${flavor.flavorName} -t lib/main_${flavor.entryPoint}.dart'
+          '  ${styleDim.wrap('# ${flavor.displayName}')}',
+        );
+      }
+      _logger.info('');
     } catch (e) {
       progress.fail('Failed to create project');
       _logger

--- a/lib/presentation/controllers/cli_controller.dart
+++ b/lib/presentation/controllers/cli_controller.dart
@@ -385,11 +385,22 @@ class CliController {
   Future<void> _createProject(ProjectConfig config) async {
     _logger.info('');
 
+    if (!await _projectRepository.isFlutterInstalled()) {
+      _logger
+        ..err('Flutter is not installed or not on your PATH.')
+        ..detail('Install Flutter, verify with `flutter doctor`, then retry.');
+      return;
+    }
+
     final progress = _logger.progress('Creating Flutter project...');
 
     try {
-      await _projectRepository.createProject(config);
-      progress.complete('Project created successfully');
+      final warnings = await _projectRepository.createProject(config);
+      progress.complete(
+        warnings.isEmpty
+            ? 'Project created successfully'
+            : 'Project created with ${warnings.length} warning(s)',
+      );
 
       final firstFlavor = config.flavors.first;
       final native = config.usesNativeFlavors;
@@ -411,6 +422,15 @@ class CliController {
         );
       }
       _logger.info('');
+
+      if (warnings.isNotEmpty) {
+        _logger.warn('Some post-generation steps need your attention:');
+        for (final warning in warnings) {
+          _logger.info('    - $warning');
+        }
+        _logger.info(styleDim.wrap('  The project was created; finish these steps manually.'));
+        _logger.info('');
+      }
     } catch (e) {
       progress.fail('Failed to create project');
       _logger

--- a/lib/presentation/controllers/cli_controller.dart
+++ b/lib/presentation/controllers/cli_controller.dart
@@ -15,6 +15,7 @@ class CliController {
     final projectName = _getProjectName();
     final organization = _getOrganization(projectName);
     final platforms = _getPlatforms();
+    final flavors = _getFlavors();
     final includeLinterRules = _getLinterRulesChoice();
 
     final config = ProjectConfig(
@@ -31,6 +32,7 @@ class CliController {
           ? DesktopPlatform.custom
           : DesktopPlatform.all,
       customDesktopPlatforms: _selectedDesktopPlatforms,
+      flavors: flavors,
     );
 
     _printConfigurationSummary(config);
@@ -282,6 +284,26 @@ class CliController {
     return platforms;
   }
 
+  List<Flavor> _getFlavors() {
+    final selected = _logger.chooseAny<Flavor>(
+      '${lightCyan.wrap('?')} Which flavors do you want to generate? '
+      '${styleDim.wrap('(space to toggle, enter to confirm)')}',
+      choices: Flavor.values,
+      defaultValues: Flavor.values,
+      display: (flavor) => flavor.displayName,
+    );
+
+    if (selected.isEmpty) {
+      _logger.warn(
+        'No flavors selected. Defaulting to all (dev, staging, production).',
+      );
+      return const [Flavor.dev, Flavor.staging, Flavor.production];
+    }
+
+    // Preserve canonical order (dev, staging, production).
+    return Flavor.values.where(selected.contains).toList();
+  }
+
   bool _getLinterRulesChoice() {
     return _logger.confirm(
       '${lightCyan.wrap('?')} Include custom linter rules?',
@@ -305,7 +327,7 @@ class CliController {
       ..info('  ${label('Navigation:')}    ${value('Go Router')}')
       ..info('  ${label('Architecture:')}  ${value('Clean Architecture')}')
       ..info('  ${label('Code Gen:')}      ${value('Freezed')}')
-      ..info('  ${label('Environments:')}  ${value('Dev, Staging, Production')}');
+      ..info('  ${label('Flavors:')}       ${value(config.flavors.map((f) => f.displayName).join(', '))}');
     if (config.includeLinterRules) {
       _logger.info('  ${label('Linter:')}        ${value('Custom Rules')}');
     }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,6 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND.
+// Regenerate with: dart run tool/generate_version.dart
+// Kept in sync with pubspec.yaml by the auto-version-bump workflow.
+
+/// The current VGV CLI version, baked at build time from pubspec.yaml.
+const String packageVersion = '1.10.39';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // Kept in sync with pubspec.yaml by the auto-version-bump workflow.
 
 /// The current VGV CLI version, baked at build time from pubspec.yaml.
-const String packageVersion = '1.10.39';
+const String packageVersion = '1.10.50';

--- a/lib/vgv_cli.dart
+++ b/lib/vgv_cli.dart
@@ -128,8 +128,13 @@ class VgvCli {
         return;
       }
 
-      // Run in interactive mode
-      await _runInteractiveMode();
+      // Run in interactive mode, honoring any flags the user did pass
+      // (org / output / no-git) instead of silently ignoring them.
+      await _runInteractiveMode(
+        organization: organization,
+        outputDir: outputDir,
+        noGit: noGit,
+      );
     } catch (e) {
       print('Error: $e');
       _printUsage();
@@ -167,8 +172,16 @@ class VgvCli {
     }
   }
 
-  Future<void> _runInteractiveMode() async {
-    await _cliController.runInteractiveMode();
+  Future<void> _runInteractiveMode({
+    String? organization,
+    String? outputDir,
+    bool noGit = false,
+  }) async {
+    await _cliController.runInteractiveMode(
+      organization: organization,
+      outputDir: outputDir,
+      noGit: noGit,
+    );
   }
 
   Future<void> _runDryRun(String? projectName, String? organization, String? outputDir) async {

--- a/lib/vgv_cli.dart
+++ b/lib/vgv_cli.dart
@@ -137,60 +137,12 @@ class VgvCli {
     }
   }
 
-  Future<void> _showUpdateProgress() async {
-    print('${AnsiColors.brightCyan}${AnsiColors.bold}Update Progress${AnsiColors.reset}');
-    print('');
-
-    final steps = [
-      {'text': 'Checking for latest version', 'duration': 600},
-      {'text': 'Downloading new version', 'duration': 1200},
-      {'text': 'Installing dependencies', 'duration': 1000},
-      {'text': 'Updating global package', 'duration': 800},
-      {'text': 'Finalizing installation', 'duration': 600},
-    ];
-
-    for (int i = 0; i < steps.length; i++) {
-      final step = steps[i];
-
-      print('${AnsiColors.brightCyan}${AnsiColors.bold}[${i + 1}/${steps.length}]${AnsiColors.reset} ${AnsiColors.brightYellow}${step['text']}${AnsiColors.reset}');
-
-      stdout.write('${AnsiColors.dim}    ${_getSpinner(0)} [${_getProgressBar(0)}] 0%${AnsiColors.reset}');
-
-      for (int p = 0; p <= 100; p += 5) {
-        await Future.delayed(Duration(milliseconds: (step['duration'] as int) ~/ 20));
-        stdout.write('\r${AnsiColors.dim}    ${_getSpinner(p ~/ 5)} [${_getProgressBar(p)}] ${p.toString().padLeft(3)}%${AnsiColors.reset}');
-      }
-
-      print(' ${AnsiColors.brightGreen}done${AnsiColors.reset}');
-    }
-
-    print('');
-    print('${AnsiColors.brightGreen}${AnsiColors.bold}All steps completed successfully${AnsiColors.reset}');
-    print('');
-  }
-
   Future<void> _showCompletionCelebration() async {
     print('');
     print('${AnsiColors.brightMagenta}${AnsiColors.bold}╔══════════════════════════════════════════════════════════════╗${AnsiColors.reset}');
     print('${AnsiColors.brightMagenta}${AnsiColors.bold}║${AnsiColors.reset}${AnsiColors.brightGreen}${AnsiColors.bold}                       UPDATE COMPLETE                        ${AnsiColors.reset}${AnsiColors.brightMagenta}${AnsiColors.bold}║${AnsiColors.reset}');
     print('${AnsiColors.brightMagenta}${AnsiColors.bold}╚══════════════════════════════════════════════════════════════╝${AnsiColors.reset}');
     print('');
-  }
-
-  String _getProgressBar(int percentage) {
-    const int barLength = 20;
-    final filledLength = (percentage / 100 * barLength).round();
-    final emptyLength = barLength - filledLength;
-
-    final filled = '█' * filledLength;
-    final empty = '░' * emptyLength;
-
-    return filled + empty;
-  }
-
-  String _getSpinner(int step) {
-    final spinners = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-    return spinners[step % spinners.length];
   }
 
   Future<void> _checkForUpdates() async {
@@ -288,9 +240,8 @@ class VgvCli {
 
     try {
       print('${AnsiColors.brightYellow}${AnsiColors.bold}Updating VGV CLI...${AnsiColors.reset}');
+      print('${AnsiColors.dim}   Downloading and installing from git (this can take a minute)...${AnsiColors.reset}');
       print('');
-
-      await _showUpdateProgress();
 
       final result = Process.runSync('dart', [
         'pub',

--- a/lib/vgv_cli.dart
+++ b/lib/vgv_cli.dart
@@ -5,6 +5,7 @@ import 'package:args/args.dart';
 import 'core/di/dependency_injection.dart';
 import 'core/utils/ansi_colors.dart';
 import 'core/utils/version_checker.dart';
+import 'domain/entities/project_config.dart';
 import 'presentation/controllers/cli_controller.dart';
 
 // Short alias for AnsiColors to keep print statements readable
@@ -65,6 +66,10 @@ class VgvCli {
         abbr: 'o',
         help: 'Output directory (defaults to current directory)',
       )
+      ..addOption(
+        'flavors',
+        help: 'Comma-separated flavors to generate: dev,staging,prod (default: all)',
+      )
       ..addFlag(
         'no-git',
         help: 'Skip git initialization',
@@ -111,6 +116,7 @@ class VgvCli {
       final noGit = _argResults['no-git'] as bool;
       final dryRun = _argResults['dry-run'] as bool;
       final quickMode = _argResults['quick'] as bool;
+      final flavors = _parseFlavors(_argResults['flavors'] as String?);
 
       if (dryRun) {
         await _runDryRun(projectName, organization, outputDir);
@@ -124,16 +130,18 @@ class VgvCli {
           outputDir: outputDir,
           noGit: noGit,
           quickMode: quickMode,
+          flavors: flavors,
         );
         return;
       }
 
       // Run in interactive mode, honoring any flags the user did pass
-      // (org / output / no-git) instead of silently ignoring them.
+      // (org / output / no-git / flavors) instead of silently ignoring them.
       await _runInteractiveMode(
         organization: organization,
         outputDir: outputDir,
         noGit: noGit,
+        flavors: flavors,
       );
     } catch (e) {
       print('Error: $e');
@@ -172,15 +180,38 @@ class VgvCli {
     }
   }
 
+  /// Parses `--flavors dev,staging,prod` into a canonical, de-duplicated list.
+  /// Returns null when the flag is absent (callers then use the default set).
+  /// Exits with code 1 on an unknown token.
+  List<Flavor>? _parseFlavors(String? arg) {
+    if (arg == null || arg.trim().isEmpty) return null;
+    final selected = <Flavor>{};
+    for (final token in arg.split(',')) {
+      if (token.trim().isEmpty) continue;
+      final flavor = Flavor.tryParse(token);
+      if (flavor == null) {
+        print('${AnsiColors.brightRed}${AnsiColors.bold}Error:${AnsiColors.reset} '
+            'unknown flavor "${token.trim()}". Valid values: dev, staging, prod.');
+        exit(1);
+      }
+      selected.add(flavor);
+    }
+    if (selected.isEmpty) return null;
+    // Preserve canonical order (dev, staging, production).
+    return Flavor.values.where(selected.contains).toList();
+  }
+
   Future<void> _runInteractiveMode({
     String? organization,
     String? outputDir,
     bool noGit = false,
+    List<Flavor>? flavors,
   }) async {
     await _cliController.runInteractiveMode(
       organization: organization,
       outputDir: outputDir,
       noGit: noGit,
+      flavors: flavors,
     );
   }
 
@@ -214,6 +245,7 @@ class VgvCli {
     String? outputDir,
     bool noGit = false,
     bool quickMode = false,
+    List<Flavor>? flavors,
   }) async {
     await _cliController.runWithFlags(
       projectName: projectName,
@@ -221,6 +253,7 @@ class VgvCli {
       outputDir: outputDir,
       noGit: noGit,
       quickMode: quickMode,
+      flavors: flavors,
     );
   }
 
@@ -355,6 +388,7 @@ class VgvCli {
     print('  ${AnsiColors.brightCyan}-n, --name${AnsiColors.reset} <name>            ${AnsiColors.dim}Project name${AnsiColors.reset}');
     print('  ${AnsiColors.brightCyan}    --org${AnsiColors.reset} <org>              ${AnsiColors.dim}Organization (com.example)${AnsiColors.reset}');
     print('  ${AnsiColors.brightCyan}-o, --output${AnsiColors.reset} <dir>           ${AnsiColors.dim}Output directory${AnsiColors.reset}');
+    print('  ${AnsiColors.brightCyan}    --flavors${AnsiColors.reset} <list>          ${AnsiColors.dim}Flavors: dev,staging,prod (default all)${AnsiColors.reset}');
     print('  ${AnsiColors.brightCyan}    --no-git${AnsiColors.reset}                 ${AnsiColors.dim}Skip git initialization${AnsiColors.reset}');
     print('  ${AnsiColors.brightCyan}    --dry-run${AnsiColors.reset}                ${AnsiColors.dim}Preview without creating${AnsiColors.reset}');
     print('');

--- a/lib/vgv_cli.dart
+++ b/lib/vgv_cli.dart
@@ -82,27 +82,9 @@ class VgvCli {
     _cliController = DependencyInjection.instance.cliController;
   }
 
-  /// Initialize version file if it doesn't exist
-  void _initializeVersionFile() {
-    try {
-      // Only initialize if the file doesn't exist
-      if (VersionChecker.getInstalledVersionFromFile() == null) {
-        final currentVersion = VersionChecker.getCurrentVersion();
-        if (currentVersion != '1.0.0') {
-          VersionChecker.saveInstalledVersion(currentVersion);
-        }
-      }
-    } catch (e) {
-      stderr.writeln('Warning: Could not initialize version file: $e');
-    }
-  }
-
   Future<void> run(List<String> arguments) async {
     try {
       _argResults = _argParser.parse(arguments);
-
-      // Initialize version file if it doesn't exist (first run)
-      _initializeVersionFile();
 
       if (_argResults['help']) {
         _printUsage();
@@ -284,13 +266,7 @@ class VgvCli {
     print('${AnsiColors.brightCyan}${AnsiColors.bold}╚══════════════════════════════════════════════════════════════╝${AnsiColors.reset}');
     print('');
 
-    String currentVersion = _version;
-    if (currentVersion == '1.0.0') {
-      final gitCurrentVersion = await VersionChecker.getLatestCLIVersionFromGit();
-      if (gitCurrentVersion != null) {
-        currentVersion = gitCurrentVersion;
-      }
-    }
+    final currentVersion = _version;
     print('${AnsiColors.brightGreen}${AnsiColors.bold}Current:${AnsiColors.reset} ${AnsiColors.brightYellow}$currentVersion${AnsiColors.reset}');
 
     final latestVersion = await VersionChecker.getLatestCLIVersionAny();
@@ -326,16 +302,8 @@ class VgvCli {
       ], runInShell: true);
 
       if (result.exitCode == 0) {
-        final newVersion = await VersionChecker.getLatestCLIVersionAny();
-        if (newVersion != null) {
-          VersionChecker.saveInstalledVersion(newVersion);
-        } else {
-          final currentVersion = VersionChecker.getCurrentVersion();
-          if (currentVersion != '1.0.0') {
-            VersionChecker.saveInstalledVersion(currentVersion);
-          }
-        }
-
+        // The freshly activated package carries its own baked version, so
+        // there is nothing to persist locally.
         await _showCompletionCelebration();
         print('${AnsiColors.brightGreen}${AnsiColors.bold}VGV CLI updated successfully${AnsiColors.reset}');
         print('');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,14 +41,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  characters:
-    dependency: transitive
-    description:
-      name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.1"
   cli_config:
     dependency: transitive
     description:
@@ -57,14 +49,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
-  clock:
-    dependency: transitive
-    description:
-      name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.2"
   collection:
     dependency: transitive
     description:
@@ -97,14 +81,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
-  dart_console:
-    dependency: transitive
-    description:
-      name: dart_console
-      sha256: dfa4b63eb4382325ff975fdb6b7a0db8303bb5809ee5cb4516b44153844742ed
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
   ffi:
     dependency: transitive
     description:
@@ -161,22 +137,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
-  interact:
-    dependency: "direct main"
-    description:
-      name: interact
-      sha256: b1abf79334bec42e58496a054cb7ee7ca74da6181f6a1fb6b134f1aa22bc4080
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.18.1"
   io:
     dependency: transitive
     description:
@@ -201,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  mason_logger:
+    dependency: "direct main"
+    description:
+      name: mason_logger
+      sha256: "1d46102c6f299c0df7fe986dd3dd3271d57c2ec7c00ae590660b7c3018810048"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5"
   matcher:
     dependency: transitive
     description:
@@ -377,14 +345,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.15"
-  tint:
-    dependency: transitive
-    description:
-      name: tint
-      sha256: "9652d9a589f4536d5e392cf790263d120474f15da3cf1bee7f1fdb31b4de5f46"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vgv_cli
 description: A powerful Flutter CLI tool for creating projects with interactive prompts, supporting Clean Architecture, BLoC, Freezed, Go Router, and internationalization.
-version: 1.10.49
+version: 1.10.50
 homepage: https://github.com/victorsdd01/vgv_cli
 repository: https://github.com/victorsdd01/vgv_cli.git
 issue_tracker: https://github.com/victorsdd01/vgv_cli/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   args: ^2.7.0
   path: ^1.9.1
   http: ^1.2.0
-  interact: ^2.2.0
+  mason_logger: ^0.3.5
 
 dev_dependencies:
   lints: ^5.1.1

--- a/tool/generate_version.dart
+++ b/tool/generate_version.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+/// Bakes the version from `pubspec.yaml` into `lib/src/version.dart`.
+///
+/// This is the single source of truth for the CLI's own version at runtime:
+/// reading `pubspec.yaml` at runtime is unreliable for a globally activated
+/// package. Run locally with `dart run tool/generate_version.dart`; the
+/// auto-version-bump workflow runs it whenever it bumps the version.
+void main() {
+  final pubspec = File('pubspec.yaml');
+  if (!pubspec.existsSync()) {
+    stderr.writeln('pubspec.yaml not found (run from the package root).');
+    exit(1);
+  }
+
+  final match = RegExp(r'^version:\s*(\S+)', multiLine: true)
+      .firstMatch(pubspec.readAsStringSync());
+  if (match == null) {
+    stderr.writeln('Could not find a version in pubspec.yaml.');
+    exit(1);
+  }
+
+  final version = match.group(1)!;
+  final out = File('lib/src/version.dart')..parent.createSync(recursive: true);
+  out.writeAsStringSync('''// GENERATED CODE - DO NOT MODIFY BY HAND.
+// Regenerate with: dart run tool/generate_version.dart
+// Kept in sync with pubspec.yaml by the auto-version-bump workflow.
+
+/// The current VGV CLI version, baked at build time from pubspec.yaml.
+const String packageVersion = '$version';
+''');
+  stdout.writeln('Wrote lib/src/version.dart ($version)');
+}


### PR DESCRIPTION
Trabajo de la sesión 2026-08-07 (rama develop → main).

## Features
- **UI**: migración de `interact` a `mason_logger` (prompts estilo Mason: chooseOne/chooseAny, confirm, progress).
- **Flavors nativos** dev/staging/production:
  - Android `productFlavors` en `build.gradle.kts` (+ `buildFeatures { resValues = true }` para AGP 8+, manifest `@string/app_name`).
  - iOS: xcconfig `<BuildType>-<flavor>` + build configs en `pbxproj` + schemes por flavor; bundle id por flavor.
  - Entry points + `launch.json` flavor-aware; prompt para elegir cuáles; preview de bundle IDs.
  - Flag `--flavors dev,staging,prod` para selección no-interactiva.
  - Verificado con builds reales: `app-dev-debug.apk` (Android) y `Runner.app` bundle `...dev` (iOS).

## Fixes
- **Update/versión**: fuente única de verdad (`lib/src/version.dart` horneado vía `tool/generate_version.dart`); `latest` = pubspec de `main`; eliminado `~/.vgv_version` frágil; CI sincroniza la constante.
- **Bug hunt** (P1/P2/P3): `-o/--output` y `--no-git` ahora funcionan (+ git init); pubspec ya no mete el SDK/cupertino_icons en dev_dependencies; flavors gateados para web/desktop; pre-check de Flutter; warnings reales si falla build_runner/l10n; regex de org; `compareVersions` defensivo; sin barra de progreso falsa en update; `--org/-o/--no-git` honrados en interactivo.

analyze limpio · 31 tests pasando · verificado end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)