### PR TITLE
release: iOS display name fix + flavor banner icons + Talker viewer (v1.10.51)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,11 @@ Configurar **flavors nativos reales** (Android `productFlavors` en `build.gradle
     - iOS: `✓ Runner.app`, bundle `com.flavortest.flavorTest.dev` (flavor dev aplicado).
     - Chequeos confirmados en el proyecto generado: auth state con **freezed** (igual que JornaDay), build_runner generó `*.freezed.dart`/`*.g.dart`, capas de datos completas (data/domain/presentation en auth+home), states custom `core/states/tstateless.dart` + `tstatefull.dart`.
 
+### 1.b.2 Pulido de flavors (2026-08-08, sobre feedback del usuario probando en iOS)
+- **Fix display name iOS**: `flutter create` hardcodea `CFBundleDisplayName` → las 3 apps mostraban el mismo nombre. `configureFlavors` ahora parchea `Info.plist` a `$(BUNDLE_DISPLAY_NAME)` (lo controla el xcconfig por flavor). Android ya estaba bien (`resValue app_name`).
+- **Iconos con banner diagonal por flavor** (`lib/core/utils/flavor_icon_generator.dart`, paquete `image`): dev/staging obtienen un ícono con **banner diagonal en la esquina inferior-derecha** ("DEV" rojo / "STAGING" ámbar); prod queda limpio. iOS: `AppIcon-<flavor>.appiconset` + `ASSETCATALOG_COMPILER_APPICON_NAME` por flavor. Android: `src/<flavor>/res/mipmap-*/ic_launcher.png` (merge por gradle). Se compone desde el master 1024 y se reescala.
+- **Talker visible salvo en prod**: no había UI para ver logs. Se agregó un botón flotante (bug icon, abajo-izquierda) que abre `TalkerScreen` vía `AppRoutes.navigator`, mostrado solo si `!AppConfiguration.isProduction`. `TalkerService.instance` hace lazy-init (no crashea). En el template (`_main_dart` builder + `AppRoutes.navigator`).
+
 ### 1.c Bug hunt del CLI (feature #9) — hallazgos y estado
 Análisis exhaustivo del CLI (2026-08-07). Arreglados:
 - **P1** `-o/--output` se ignoraba (proyecto siempre en CWD) → `createProject` ahora hace `Directory.current = outputDir`.

--- a/lib/core/templates/template_contents.dart
+++ b/lib/core/templates/template_contents.dart
@@ -2733,6 +2733,7 @@ import 'package:nested/nested.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:talker_flutter/talker_flutter.dart';
 
 import 'application/application.dart';
 import 'application/config/config.dart';
@@ -2804,19 +2805,47 @@ class MyApp extends StatelessWidget {
       supportedLocales: AppLocalizationsSetup.supportedLocales,
       debugShowCheckedModeBanner: false,
       builder: (BuildContext context, Widget? child) {
-        if (kReleaseMode) return child ?? const SizedBox.shrink();
-        
-        return Banner(
-          message: _getBannerText(),
-          location: BannerLocation.topEnd,
-          color: _getBannerColor(),
-          textStyle: const TextStyle(
-            color: Colors.white,
-            fontSize: 10,
-            fontWeight: FontWeight.bold,
-            letterSpacing: 1.2,
-          ),
-          child: child ?? const SizedBox.shrink(),
+        final Widget content = child ?? const SizedBox.shrink();
+        final Widget withBanner = kReleaseMode
+            ? content
+            : Banner(
+                message: _getBannerText(),
+                location: BannerLocation.topEnd,
+                color: _getBannerColor(),
+                textStyle: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 10,
+                  fontWeight: FontWeight.bold,
+                  letterSpacing: 1.2,
+                ),
+                child: content,
+              );
+
+        // Talker log viewer: available in every flavor except production.
+        if (AppConfiguration.isProduction) return withBanner;
+
+        return Stack(
+          children: <Widget>[
+            withBanner,
+            Positioned(
+              left: 16,
+              bottom: 24,
+              child: SafeArea(
+                child: FloatingActionButton.small(
+                  heroTag: 'talkerLogsButton',
+                  backgroundColor: Colors.black87,
+                  tooltip: 'Logs (Talker)',
+                  onPressed: () => AppRoutes.navigator?.push(
+                    MaterialPageRoute<void>(
+                      builder: (BuildContext _) =>
+                          TalkerScreen(talker: TalkerService.instance),
+                    ),
+                  ),
+                  child: const Icon(Icons.bug_report, color: Colors.white),
+                ),
+              ),
+            ),
+          ],
         );
       },
     ),
@@ -3504,6 +3533,9 @@ class AppRoutes {
   static final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
 
   static BuildContext? get globalContext => _navigatorKey.currentContext;
+
+  /// Root navigator, used e.g. to open the Talker log screen in non-prod.
+  static NavigatorState? get navigator => _navigatorKey.currentState;
 
   static final GoRouter router = GoRouter(
     errorBuilder: (BuildContext context, GoRouterState state) {

--- a/lib/core/templates/template_contents.dart
+++ b/lib/core/templates/template_contents.dart
@@ -473,7 +473,7 @@ class ToastUtil {
       length <= maxLength ? this : '${substring(0, maxLength)}$suffix';
 }
 ''';
-  static const String _core_states_tstateless_dart = r'''import 'package:bloc/bloc.dart';
+  static const String _core_states_tstateless_dart = r'''import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter/material.dart';
 import '../../application/generated/l10n.dart';
 
@@ -497,7 +497,7 @@ abstract class TStateless<Bloc extends BlocBase<dynamic>?>
   );
 }
 ''';
-  static const String _core_states_tstatefull_dart = r'''import 'package:bloc/bloc.dart';
+  static const String _core_states_tstatefull_dart = r'''import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter/material.dart';
 import '../../application/generated/l10n.dart';
 
@@ -658,7 +658,8 @@ class SettingsBloc extends HydratedBloc<SettingsEvent, SettingsState> {
   Map<String, dynamic>? toJson(SettingsState state) => state.toJson();
 }
 ''';
-  static const String _features_settings_presentation_blocs_settings_bloc_settings_state_dart = r'''part of 'settings_bloc.dart';
+  static const String _features_settings_presentation_blocs_settings_bloc_settings_state_dart = r'''// ignore_for_file: invalid_annotation_target
+part of 'settings_bloc.dart';
 
 @freezed
 abstract class SettingsStatus with _$SettingsStatus {
@@ -1195,7 +1196,8 @@ abstract class HomeEntity with _$HomeEntity {
 }
 
 ''';
-  static const String _features_home_presentation_blocs_home_bloc_home_state_dart = r'''part of 'home_bloc.dart';
+  static const String _features_home_presentation_blocs_home_bloc_home_state_dart = r'''// ignore_for_file: invalid_annotation_target
+part of 'home_bloc.dart';
 
 @freezed
 abstract class HomeStatus with _$HomeStatus {
@@ -2046,7 +2048,8 @@ class AuthBloc extends HydratedBloc<AuthEvent, AuthState> {
   Map<String, dynamic>? toJson(AuthState state) => null;
 }
 ''';
-  static const String _features_auth_presentation_blocs_auth_bloc_auth_state_dart = r'''part of 'auth_bloc.dart';
+  static const String _features_auth_presentation_blocs_auth_bloc_auth_state_dart = r'''// ignore_for_file: invalid_annotation_target
+part of 'auth_bloc.dart';
 
 @freezed
 abstract class AuthStatus with _$AuthStatus {

--- a/lib/core/utils/flavor_icon_generator.dart
+++ b/lib/core/utils/flavor_icon_generator.dart
@@ -1,0 +1,178 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:image/image.dart' as img;
+import 'package:path/path.dart' as path;
+import '../../domain/entities/project_config.dart';
+
+/// Generates per-flavor app icons with a diagonal corner banner
+/// (e.g. "DEV" / "STAGING") for non-production flavors. Production keeps the
+/// clean default icon.
+class FlavorIconGenerator {
+  const FlavorIconGenerator();
+
+  /// iOS asset-catalog name for a flavor (production keeps the default).
+  static String iosAppIconName(Flavor flavor) =>
+      flavor == Flavor.production ? 'AppIcon' : 'AppIcon-${flavor.flavorName}';
+
+  /// Generates banner icons for every non-production flavor in [flavors].
+  /// No-op if there is no source icon (e.g. no mobile platform).
+  Future<void> generate({
+    required String projectName,
+    required List<Flavor> flavors,
+  }) async {
+    final nonProd =
+        flavors.where((f) => f != Flavor.production).toList(growable: false);
+    if (nonProd.isEmpty) return;
+
+    final master = _loadMasterIcon(projectName);
+    if (master == null) return;
+
+    for (final flavor in nonProd) {
+      final banner = buildBannerIcon(master, flavor);
+      _writeIosIcons(projectName, flavor, banner);
+      _writeAndroidIcons(projectName, flavor, banner);
+    }
+  }
+
+  /// Loads the highest-resolution source icon (iOS 1024, else Android xxxhdpi).
+  img.Image? _loadMasterIcon(String projectName) {
+    final ios1024 = File(path.join(projectName, 'ios', 'Runner',
+        'Assets.xcassets', 'AppIcon.appiconset', 'Icon-App-1024x1024@1x.png'));
+    if (ios1024.existsSync()) {
+      return img.decodePng(ios1024.readAsBytesSync());
+    }
+    final androidHi = File(path.join(projectName, 'android', 'app', 'src',
+        'main', 'res', 'mipmap-xxxhdpi', 'ic_launcher.png'));
+    if (androidHi.existsSync()) {
+      return img.decodePng(androidHi.readAsBytesSync());
+    }
+    return null;
+  }
+
+  /// Writes a per-flavor `AppIcon-<flavor>.appiconset` mirroring the sizes of
+  /// the default AppIcon set.
+  void _writeIosIcons(String projectName, Flavor flavor, img.Image banner) {
+    final baseSet = Directory(path.join(projectName, 'ios', 'Runner',
+        'Assets.xcassets', 'AppIcon.appiconset'));
+    final contentsFile = File(path.join(baseSet.path, 'Contents.json'));
+    if (!contentsFile.existsSync()) return;
+
+    final contentsRaw = contentsFile.readAsStringSync();
+    final contents = jsonDecode(contentsRaw) as Map<String, dynamic>;
+    final destDir = Directory(path.join(projectName, 'ios', 'Runner',
+        'Assets.xcassets', '${iosAppIconName(flavor)}.appiconset'));
+    destDir.createSync(recursive: true);
+
+    for (final image in (contents['images'] as List)) {
+      final map = image as Map<String, dynamic>;
+      final filename = map['filename'] as String?;
+      if (filename == null) continue;
+      final sizePt = double.parse((map['size'] as String).split('x').first);
+      final scale = int.parse((map['scale'] as String).replaceAll('x', ''));
+      final px = (sizePt * scale).round();
+      _writeResized(banner, File(path.join(destDir.path, filename)), px);
+    }
+    // Same filenames, so the base Contents.json applies verbatim.
+    File(path.join(destDir.path, 'Contents.json')).writeAsStringSync(contentsRaw);
+  }
+
+  /// Writes per-flavor Android launcher icons into the flavor source set,
+  /// which Gradle merges over `main` for that product flavor.
+  void _writeAndroidIcons(String projectName, Flavor flavor, img.Image banner) {
+    final mainRes =
+        Directory(path.join(projectName, 'android', 'app', 'src', 'main', 'res'));
+    if (!mainRes.existsSync()) return;
+    for (final entry in _androidDensities.entries) {
+      final file = File(path.join(projectName, 'android', 'app', 'src',
+          flavor.flavorName, 'res', 'mipmap-${entry.key}', 'ic_launcher.png'));
+      _writeResized(banner, file, entry.value);
+    }
+  }
+
+  // Android launcher densities → pixel size (base 48dp).
+  static const Map<String, int> _androidDensities = {
+    'mdpi': 48,
+    'hdpi': 72,
+    'xhdpi': 96,
+    'xxhdpi': 144,
+    'xxxhdpi': 192,
+  };
+
+  /// Banner color per flavor.
+  img.Color _bandColor(Flavor flavor) {
+    switch (flavor) {
+      case Flavor.dev:
+        return img.ColorRgba8(0xE5, 0x3E, 0x3E, 0xF2); // red
+      case Flavor.staging:
+        return img.ColorRgba8(0xF2, 0x9D, 0x1B, 0xF2); // amber
+      case Flavor.production:
+        return img.ColorRgba8(0x2E, 0x7D, 0x32, 0xF2); // (unused; prod = clean)
+    }
+  }
+
+  /// Composites a diagonal bottom-left banner with the flavor label onto a
+  /// square [base] icon and returns the new image.
+  img.Image buildBannerIcon(img.Image base, Flavor flavor) {
+    final size = base.width;
+    final icon = base.clone();
+    final label = flavor.flavorName.toUpperCase();
+
+    // Build the ribbon at an internal resolution where the 48px font is
+    // prominent, then scale it to the icon. Thickness is preserved by rotation.
+    const bandHeight = 110;
+    final textWidth = label.length * 28; // arial48 approximation
+    final ribbonLen = (textWidth + 220).clamp(420, 2200).toInt();
+
+    final ribbon = img.Image(width: ribbonLen, height: bandHeight, numChannels: 4);
+    img.fillRect(
+      ribbon,
+      x1: 0,
+      y1: 0,
+      x2: ribbonLen - 1,
+      y2: bandHeight - 1,
+      color: _bandColor(flavor),
+    );
+    img.drawString(
+      ribbon,
+      label,
+      font: img.arial48,
+      x: ((ribbonLen - textWidth) / 2).round(),
+      y: ((bandHeight - 48) / 2).round(),
+      color: img.ColorRgb8(255, 255, 255),
+    );
+
+    // Rotate for the bottom-right corner and scale to the icon.
+    final rotated = img.copyRotate(
+      ribbon,
+      angle: -45,
+      interpolation: img.Interpolation.linear,
+    );
+    final scale = (size * 0.16) / bandHeight;
+    final scaled = img.copyResize(
+      rotated,
+      width: (rotated.width * scale).round(),
+      height: (rotated.height * scale).round(),
+      interpolation: img.Interpolation.linear,
+    );
+
+    // Center the band on the bottom-right corner, nudged toward the middle.
+    final nudge = (size * 0.12).round();
+    final dstX = size - (scaled.width ~/ 2) - nudge;
+    final dstY = size - (scaled.height ~/ 2) - nudge;
+    img.compositeImage(icon, scaled, dstX: dstX, dstY: dstY);
+
+    return icon;
+  }
+
+  /// Writes a [master] banner image resized to [pngFile] at [size] px.
+  void _writeResized(img.Image master, File pngFile, int size) {
+    pngFile.parent.createSync(recursive: true);
+    final resized = img.copyResize(
+      master,
+      width: size,
+      height: size,
+      interpolation: img.Interpolation.average,
+    );
+    pngFile.writeAsBytesSync(img.encodePng(resized));
+  }
+}

--- a/lib/data/datasources/file_system_datasource.dart
+++ b/lib/data/datasources/file_system_datasource.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:vgv_cli/core/templates/template_generator.dart';
+import 'package:vgv_cli/core/utils/flavor_icon_generator.dart';
 import 'package:path/path.dart' as path;
 import '../../domain/entities/project_config.dart';
 
@@ -1974,6 +1975,11 @@ key.properties
     if (config.flavors.isEmpty) return;
     await _configureAndroidFlavors(config);
     await _configureIosFlavors(config);
+    // Per-flavor launcher icons with a diagonal banner (dev/staging).
+    await const FlavorIconGenerator().generate(
+      projectName: config.projectName,
+      flavors: config.flavors,
+    );
   }
 
   /// Converts a package name into a human friendly app name.
@@ -2330,7 +2336,7 @@ key.properties
     return '#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.$lower-${flavor.flavorName}.xcconfig"\n'
         '#include "Generated.xcconfig"\n'
         'FLUTTER_TARGET=lib/main_${flavor.entryPoint}.dart\n'
-        'ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon\n'
+        'ASSETCATALOG_COMPILER_APPICON_NAME=${FlavorIconGenerator.iosAppIconName(flavor)}\n'
         'PRODUCT_BUNDLE_IDENTIFIER=${flavor.bundleId(baseBundleId)}\n'
         'BUNDLE_DISPLAY_NAME=$appName${flavor.appNameSuffix}\n';
   }

--- a/lib/data/datasources/file_system_datasource.dart
+++ b/lib/data/datasources/file_system_datasource.dart
@@ -2138,6 +2138,10 @@ key.properties
     // iOS platform was not generated for this project.
     if (!pbxFile.existsSync()) return;
 
+    // Wire the display name to the per-flavor xcconfig value so each flavor
+    // shows its own name (flutter create hardcodes CFBundleDisplayName).
+    _patchIosInfoPlistDisplayName(iosDir);
+
     var pbx = pbxFile.readAsStringSync();
     final firstFlavor = config.flavors.first.flavorName;
     if (pbx.contains('/* Debug-$firstFlavor */')) return; // idempotent
@@ -2253,6 +2257,20 @@ key.properties
   /// The `FF` prefix guarantees no clash with `flutter create`'s ids.
   String _pbxId(int seed) =>
       'FF${seed.toRadixString(16).toUpperCase().padLeft(22, '0')}';
+
+  /// Points `CFBundleDisplayName` at `$(BUNDLE_DISPLAY_NAME)` so each flavor's
+  /// xcconfig controls the visible app name (default is a hardcoded literal).
+  void _patchIosInfoPlistDisplayName(Directory iosDir) {
+    final plist = File(path.join(iosDir.path, 'Runner', 'Info.plist'));
+    if (!plist.existsSync()) return;
+    var content = plist.readAsStringSync();
+    if (content.contains(r'$(BUNDLE_DISPLAY_NAME)')) return; // idempotent
+    content = content.replaceFirstMapped(
+      RegExp(r'(<key>CFBundleDisplayName</key>\s*<string>)[^<]*(</string>)'),
+      (m) => '${m.group(1)}\$(BUNDLE_DISPLAY_NAME)${m.group(2)}',
+    );
+    plist.writeAsStringSync(content);
+  }
 
   /// Reads the base (production) bundle id from the Runner target settings,
   /// ignoring the RunnerTests identifier.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -3,4 +3,4 @@
 // Kept in sync with pubspec.yaml by the auto-version-bump workflow.
 
 /// The current VGV CLI version, baked at build time from pubspec.yaml.
-const String packageVersion = '1.10.50';
+const String packageVersion = '1.10.51';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.1"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.9"
   args:
     dependency: "direct main"
     description:
@@ -137,6 +145,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image:
+    dependency: "direct main"
+    description:
+      name: image
+      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.9.1"
   io:
     dependency: transitive
     description:
@@ -217,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   pool:
     dependency: transitive
     description:
@@ -225,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.2"
   pub_semver:
     dependency: transitive
     description:
@@ -409,6 +441,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.13.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:
@@ -418,4 +458,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vgv_cli
 description: A powerful Flutter CLI tool for creating projects with interactive prompts, supporting Clean Architecture, BLoC, Freezed, Go Router, and internationalization.
-version: 1.10.50
+version: 1.10.51
 homepage: https://github.com/victorsdd01/vgv_cli
 repository: https://github.com/victorsdd01/vgv_cli.git
 issue_tracker: https://github.com/victorsdd01/vgv_cli/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   path: ^1.9.1
   http: ^1.2.0
   mason_logger: ^0.3.5
+  image: ^4.9.1
 
 dev_dependencies:
   lints: ^5.1.1


### PR DESCRIPTION
Sobre feedback probando en iOS.

## Cambios
- **fix(iOS display name)**: `CFBundleDisplayName` → `$(BUNDLE_DISPLAY_NAME)` para que cada flavor muestre su nombre (antes las 3 apps decían lo mismo).
- **feat(iconos con banner)**: dev/staging obtienen ícono con banner diagonal (esquina inf-derecha) "DEV"(rojo)/"STAGING"(ámbar); prod limpio. Android (`src/<flavor>/res/mipmap-*`) + iOS (`AppIcon-<flavor>.appiconset` + `ASSETCATALOG_COMPILER_APPICON_NAME`). Paquete `image`.
- **feat(Talker)**: botón flotante que abre `TalkerScreen`, visible solo si el flavor no es production.
- **chore**: silenciados warnings de analyzer del template (freezed `invalid_annotation_target`, import `flutter_bloc`); bump a 1.10.51.

Verificado: `flutter analyze` del proyecto generado sin errores; builds Android+iOS OK en releases previos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)